### PR TITLE
feat(dashboard): replace flat shell with attyjuan-sched sidebar layout

### DIFF
--- a/src/app/dashboard/leads/page.tsx
+++ b/src/app/dashboard/leads/page.tsx
@@ -1,0 +1,16 @@
+export default function LeadsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-foreground tracking-tight">Leads</h2>
+        <p className="mt-1 text-[14px] text-muted-foreground">View and manage incoming leads from your contact forms.</p>
+      </div>
+      <div className="rounded-2xl border border-white/[0.06] bg-white/[0.015] p-1.5 inner-highlight">
+        <div className="rounded-[calc(1rem-0.375rem)] bg-card px-6 py-16 text-center">
+          <p className="text-[14px] font-medium text-foreground mb-1">Lead inbox coming in Phase 5</p>
+          <p className="text-[13px] text-muted-foreground">Once your contact form is live, leads will appear here.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,44 +1,12 @@
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
+import { getUserProfile } from "@/services/dashboard";
 import { DashboardShell } from "@/components/dashboard-shell";
-import { getUserProfile, getVibeCheckData } from "@/services/dashboard";
 import { redirect } from "next/navigation";
-import { creatorRepos } from "@/lib/config";
 
 export default async function DashboardPage() {
   const session = await getUserProfile();
-  
-  if (!session?.user) {
-    redirect("/login");
-  }
+  if (!session?.user) redirect("/login");
 
   const { user, profile } = session;
-  const profiles = await getVibeCheckData() || [];
-  const repos = creatorRepos;
 
-  return (
-    <div className="min-h-screen bg-background">
-      <Navbar user={user} />
-      
-      <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10 md:py-20">
-        <div className="mb-12">
-          <h1 className="text-4xl font-black text-foreground tracking-tighter uppercase italic leading-none">
-            Mission Control
-          </h1>
-          <p className="mt-2 text-muted-foreground font-semibold italic">
-            Welcome back, {profile?.full_name || user.email?.split("@")[0]}. Systems are nominal.
-          </p>
-        </div>
-
-        <DashboardShell 
-          user={user} 
-          profile={profile} 
-          profiles={profiles} 
-          repos={repos} 
-        />
-      </main>
-
-      <Footer />
-    </div>
-  );
+  return <DashboardShell user={user} profile={profile} />;
 }

--- a/src/app/dashboard/pages/page.tsx
+++ b/src/app/dashboard/pages/page.tsx
@@ -1,0 +1,16 @@
+export default function PagesPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-foreground tracking-tight">Pages</h2>
+        <p className="mt-1 text-[14px] text-muted-foreground">Manage your landing pages and content sections.</p>
+      </div>
+      <div className="rounded-2xl border border-white/[0.06] bg-white/[0.015] p-1.5 inner-highlight">
+        <div className="rounded-[calc(1rem-0.375rem)] bg-card px-6 py-16 text-center">
+          <p className="text-[14px] font-medium text-foreground mb-1">Page editor coming in Phase 5</p>
+          <p className="text-[13px] text-muted-foreground">You'll be able to edit hero, services, testimonials, and more.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,0 +1,16 @@
+export default function SettingsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-foreground tracking-tight">Settings</h2>
+        <p className="mt-1 text-[14px] text-muted-foreground">Manage your organization, branding, and account preferences.</p>
+      </div>
+      <div className="rounded-2xl border border-white/[0.06] bg-white/[0.015] p-1.5 inner-highlight">
+        <div className="rounded-[calc(1rem-0.375rem)] bg-card px-6 py-16 text-center">
+          <p className="text-[14px] font-medium text-foreground mb-1">Settings coming in Phase 5</p>
+          <p className="text-[13px] text-muted-foreground">Logo, colors, SMTP, domain, and notification preferences.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -1,0 +1,16 @@
+export default function TeamPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-foreground tracking-tight">Team</h2>
+        <p className="mt-1 text-[14px] text-muted-foreground">Invite team members and manage roles and permissions.</p>
+      </div>
+      <div className="rounded-2xl border border-white/[0.06] bg-white/[0.015] p-1.5 inner-highlight">
+        <div className="rounded-[calc(1rem-0.375rem)] bg-card px-6 py-16 text-center">
+          <p className="text-[14px] font-medium text-foreground mb-1">Team management coming in Phase 2</p>
+          <p className="text-[13px] text-muted-foreground">Invite admins and employees, assign roles and page access.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard-shell.tsx
+++ b/src/components/dashboard-shell.tsx
@@ -2,439 +2,352 @@
 
 import * as React from "react"
 import {
-  Database,
-  GitBranch,
-  Terminal,
-  Sparkles,
-  User,
-  Shield,
-  Edit3,
-  BookOpen,
-  Activity,
-  Code2,
-  Lock,
+  LayoutDashboard,
+  FileText,
+  Inbox,
+  Users,
   Settings,
-  ShieldCheck
+  LogOut,
+  Home,
+  PanelLeftClose,
+  PanelLeft,
+  X,
+  Menu,
+  TrendingUp,
 } from "lucide-react"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { siteConfig } from "@/lib/config"
-import { ProfileForm } from "./profile-form"
-import { useInfiniteQuery } from "@tanstack/react-query"
-import { getVibeCheckDataPaginated } from "@/services/dashboard"
-import { useInView } from "react-intersection-observer"
-import { BentoSkeleton } from "./dashboard/bento-skeleton"
 import { useRouter, useSearchParams } from "next/navigation"
-import { SecurityForm } from "./security-form"
+import { createClient } from "@/utils/supabase/client"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { siteConfig } from "@/lib/config"
+import type { User as SupabaseUser } from "@supabase/supabase-js"
 
-import { PillTabs } from "@/components/ui/pill-tabs"
+/* ─────────────────────────────────────────────────────────────── */
+/*  Nav config                                                       */
+/* ─────────────────────────────────────────────────────────────── */
+const NAV_MAIN = [
+  { id: "overview",  label: "Overview",  icon: LayoutDashboard },
+  { id: "pages",     label: "Pages",     icon: FileText },
+  { id: "leads",     label: "Leads",     icon: Inbox },
+  { id: "team",      label: "Team",      icon: Users },
+]
 
-const REPOS_PER_PAGE = 5;
+/* ─────────────────────────────────────────────────────────────── */
+/*  Stat card                                                        */
+/* ─────────────────────────────────────────────────────────────── */
+function StatCard({
+  label, value, note, icon: Icon, accent,
+}: {
+  label: string; value: string; note: string; icon: React.ElementType; accent?: string
+}) {
+  return (
+    <div className="bg-card border border-border rounded-2xl px-5 py-5">
+      <div className="flex items-center justify-between mb-4">
+        <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-[0.15em]">{label}</p>
+        <div className={`flex h-8 w-8 items-center justify-center rounded-lg ${accent ?? "bg-muted"}`}>
+          <Icon className="h-4 w-4 text-muted-foreground" strokeWidth={1.5} />
+        </div>
+      </div>
+      <p className="text-3xl font-bold text-foreground tabular-nums">{value}</p>
+      <p className="mt-1 text-[11px] text-muted-foreground">{note}</p>
+    </div>
+  )
+}
 
-function RepoPagination({ repos }: { repos: any[] }) {
-  const [page, setPage] = React.useState(0);
-  const totalPages = Math.ceil(repos.length / REPOS_PER_PAGE);
-  const pageRepos = repos.slice(page * REPOS_PER_PAGE, (page + 1) * REPOS_PER_PAGE);
+/* ─────────────────────────────────────────────────────────────── */
+/*  Coming-soon placeholder                                          */
+/* ─────────────────────────────────────────────────────────────── */
+function ComingSoon({ icon: Icon, title, description, phase }: {
+  icon: React.ElementType; title: string; description: string; phase: string
+}) {
+  return (
+    <div className="rounded-2xl border border-dashed border-border bg-card flex flex-col items-center justify-center py-24 text-center px-6">
+      <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-muted border border-border mb-4">
+        <Icon className="h-6 w-6 text-muted-foreground" strokeWidth={1.5} />
+      </div>
+      <h3 className="font-semibold text-foreground mb-1">{title}</h3>
+      <p className="text-[13px] text-muted-foreground max-w-xs leading-relaxed mb-4">{description}</p>
+      <span className="text-[11px] text-muted-foreground border border-border rounded-full px-3 py-1">{phase}</span>
+    </div>
+  )
+}
+
+/* ─────────────────────────────────────────────────────────────── */
+/*  Overview tab                                                     */
+/* ─────────────────────────────────────────────────────────────── */
+function OverviewTab({ displayName, setTab }: { displayName: string; setTab: (tab: string) => void }) {
+  const today = new Date().toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric", year: "numeric" })
 
   return (
-    <div className="space-y-5">
-      {/* Creator description banner */}
-      <div className="flex items-start gap-3 px-4 py-3 rounded-2xl bg-secondary border border-border">
-        <GitBranch className="w-4 h-4 text-primary shrink-0 mt-0.5" />
-        <p className="text-[11px] font-mono text-muted-foreground leading-relaxed">
-          These are the public repositories of <span className="text-foreground font-black">Danncode10</span>, the creator of DannFlow.
-          To show <span className="text-foreground font-black">your own repos</span>, edit{" "}
-          <code className="bg-border px-1.5 py-0.5 rounded text-[10px]">src/lib/config.ts</code> → <code className="bg-border px-1.5 py-0.5 rounded text-[10px]">creatorRepos</code>.
-        </p>
+    <div className="space-y-8">
+      {/* Welcome */}
+      <div>
+        <h2 className="text-2xl font-semibold text-foreground tracking-tight">
+          Good day, {displayName}.
+        </h2>
+        <p className="text-[13px] text-muted-foreground mt-1">{today}</p>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {pageRepos.map((repo: any, i: number) => (
-          <a key={i} href={repo.url} target="_blank" rel="noopener noreferrer" className="block group">
-            <Card className="bg-card text-card-foreground border border-border group-hover:border-primary/50 hover:bg-card/80 transition-all duration-300 shadow-sm rounded-3xl h-full">
-              <CardHeader className="flex flex-row items-center justify-between pb-2">
-                <CardTitle className="text-sm font-mono text-foreground group-hover:text-primary transition-colors uppercase truncate pr-2">
-                  {repo.name}
-                </CardTitle>
-                <GitBranch className="w-4 h-4 text-muted-foreground group-hover:text-primary/70 shrink-0" />
-              </CardHeader>
-              <CardContent>
-                <p className="text-xs text-muted-foreground leading-relaxed italic line-clamp-2">
-                  "{repo.description || "No mission statement."}"
-                </p>
-              </CardContent>
-            </Card>
-          </a>
-        ))}
+      {/* Stat cards — 4-column horizontal */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+        <StatCard label="Active Pages"    value="—" note="Add your first page"      icon={FileText}        accent="bg-primary/10" />
+        <StatCard label="Today's Leads"   value="0" note="Clear inbox today"        icon={Inbox}           accent="bg-amber-500/10" />
+        <StatCard label="Total Documents" value="—" note="Upload your first file"   icon={TrendingUp}      accent="bg-blue-500/10" />
+        <StatCard label="Urgent Matters"  value="0" note="No items need attention"  icon={LayoutDashboard} accent="bg-rose-500/10" />
       </div>
 
-      {/* Pagination — [<] 1 2 3 [>] */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-center gap-2 pt-2">
-          <button
-            onClick={() => setPage(p => Math.max(0, p - 1))}
-            disabled={page === 0}
-            className="w-8 h-8 flex items-center justify-center rounded-lg border border-border text-muted-foreground hover:border-primary/50 hover:text-primary disabled:opacity-30 disabled:cursor-not-allowed transition-all text-sm font-black"
-          >
-            ‹
-          </button>
-          {Array.from({ length: totalPages }).map((_, i) => (
-            <button
-              key={i}
-              onClick={() => setPage(i)}
-              className={`w-8 h-8 flex items-center justify-center rounded-lg text-[11px] font-black transition-all border ${
-                page === i
-                  ? "bg-primary text-primary-foreground border-primary shadow-sm shadow-primary/20"
-                  : "border-border text-muted-foreground hover:border-primary/40 hover:text-foreground"
-              }`}
-            >
-              {i + 1}
-            </button>
-          ))}
-          <button
-            onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
-            disabled={page === totalPages - 1}
-            className="w-8 h-8 flex items-center justify-center rounded-lg border border-border text-muted-foreground hover:border-primary/50 hover:text-primary disabled:opacity-30 disabled:cursor-not-allowed transition-all text-sm font-black"
-          >
-            ›
-          </button>
+      {/* Two-column: Recent Activity + Upcoming */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Recent Activity */}
+        <div className="bg-card border border-border rounded-2xl overflow-hidden">
+          <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+            <h3 className="text-[13px] font-semibold text-foreground">Recent Activity</h3>
+            <button className="text-[12px] text-primary hover:underline">View all →</button>
+          </div>
+          <div className="px-5 py-10 text-center">
+            <p className="text-[13px] text-muted-foreground">No recent activity yet.</p>
+            <p className="text-[12px] text-muted-foreground/60 mt-1">Start by editing your landing page.</p>
+          </div>
         </div>
-      )}
+
+        {/* Upcoming */}
+        <div className="bg-card border border-border rounded-2xl overflow-hidden">
+          <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+            <h3 className="text-[13px] font-semibold text-foreground">Quick Actions</h3>
+          </div>
+          <div className="p-4 space-y-2">
+            {[
+              { label: "Edit landing page",  desc: "Customize your homepage",    tab: "pages" },
+              { label: "View leads",         desc: "See who reached out",        tab: "leads" },
+              { label: "Manage team",        desc: "Invite team members",        tab: "team" },
+              { label: "Settings",           desc: "Branding & preferences",     tab: "settings" },
+            ].map((a) => (
+              <button
+                key={a.tab}
+                onClick={() => setTab(a.tab)}
+                className="w-full flex items-center justify-between px-4 py-3 rounded-xl border border-border bg-background hover:border-primary/30 hover:bg-primary/[0.03] transition-all duration-200 text-left group"
+              >
+                <div>
+                  <p className="text-[13px] font-medium text-foreground group-hover:text-primary transition-colors">{a.label}</p>
+                  <p className="text-[11px] text-muted-foreground">{a.desc}</p>
+                </div>
+                <span className="text-muted-foreground group-hover:text-primary text-xs">→</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
     </div>
-  );
+  )
 }
 
+/* ─────────────────────────────────────────────────────────────── */
+/*  Main shell                                                       */
+/* ─────────────────────────────────────────────────────────────── */
 interface DashboardShellProps {
-  profiles: any[]
-  user: any
-  profile: any
-  repos: any[]
+  user: SupabaseUser
+  profile: { full_name?: string | null; role?: string | null } | null
 }
 
-export function DashboardShell({ profiles, user, profile, repos }: DashboardShellProps) {
+export function DashboardShell({ user, profile }: DashboardShellProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
-  const initialTab = searchParams.get("tab") || "overview"
-  const [activeTab, setActiveTabLocal] = React.useState(initialTab)
+  const [activeTab, setActiveTabLocal] = React.useState(searchParams.get("tab") || "overview")
+  const [sidebarOpen, setSidebarOpen] = React.useState(false)
+  const [collapsed, setCollapsed] = React.useState(false)
+  const [userMenuOpen, setUserMenuOpen] = React.useState(false)
 
-  const setActiveTab = (tab: string) => {
+  const displayName = profile?.full_name || user.email?.split("@")[0] || "there"
+  const initials = displayName.split(" ").map((n: string) => n[0]).join("").slice(0, 2).toUpperCase()
+
+  const setTab = (tab: string) => {
     setActiveTabLocal(tab)
     router.push(`/dashboard?tab=${tab}`, { scroll: false })
+    setSidebarOpen(false)
   }
 
-  const { ref, inView } = useInView()
+  const handleSignOut = async () => {
+    const supabase = createClient()
+    await supabase.auth.signOut()
+    router.push("/login")
+    router.refresh()
+  }
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
-    queryKey: ['profiles-db'],
-    queryFn: ({ pageParam = 0 }) => getVibeCheckDataPaginated({ pageParam }),
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, allPages) => lastPage.length === 5 ? allPages.length : undefined,
-    initialData: { pages: [profiles], pageParams: [0] }
-  });
-
-  React.useEffect(() => {
-    if (inView && hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
-    }
-  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
-
-  const displayProfiles = data?.pages.flat() || profiles;
-
-  const DASHBOARD_TABS = [
-    { id: "overview", label: "Overview", icon: Activity },
-    { id: "database", label: "Database", icon: Database },
-    { id: "code", label: "Code", icon: Code2 },
-    { id: "docs", label: "Docs", icon: BookOpen },
-    { id: "security", label: "Security", icon: ShieldCheck },
-    { id: "settings", label: "Settings", icon: Settings },
-  ]
+  const activeLabel = [...NAV_MAIN, { id: "settings", label: "Settings", icon: Settings }]
+    .find(i => i.id === activeTab)?.label ?? "Overview"
 
   return (
-    <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-      <div className="flex flex-col md:flex-row md:items-center justify-between mb-8 gap-4">
-        <PillTabs items={DASHBOARD_TABS} active={activeTab} onChange={setActiveTab} className="mb-0" />
+    <div className="h-screen bg-background flex overflow-hidden">
 
+      {/* ── Mobile overlay ─────────────────────────────────────────────── */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-foreground/20 backdrop-blur-sm md:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
 
-        <div className="flex items-center gap-3">
-          {profile?.role === 'admin' && (
-            <Badge variant="outline" className="text-primary border-primary/20 bg-primary/10 gap-1 px-3 py-1">
-              <Lock className="w-3 h-3" />
-              Admin Mode
-            </Badge>
-          )}
-          <Badge variant="secondary" className="font-mono text-[10px] uppercase tracking-wider">
-            v1.1.0-alpha
-          </Badge>
-        </div>
-      </div>
+      {/* ── Sidebar ────────────────────────────────────────────────────── */}
+      <aside className={`
+        fixed inset-y-0 left-0 z-50 bg-card border-r border-border flex flex-col
+        transition-all duration-200 ease-in-out
+        ${sidebarOpen ? "translate-x-0" : "-translate-x-full"}
+        ${collapsed ? "md:w-14" : "md:w-56"}
+        w-56 md:translate-x-0 md:relative md:z-auto md:h-full md:flex-shrink-0
+      `}>
 
-      {/* 1. Overview Tab */}
-      <TabsContent value="overview" className="space-y-12 animate-in fade-in duration-500">
-        <div className="grid grid-cols-1 md:grid-cols-12 gap-6 lg:gap-8">
-          <Card className="col-span-1 md:col-span-4 bg-card text-card-foreground border border-border shadow-sm hover:scale-[1.01] transition-all group rounded-3xl rounded-tl-xl p-2">
-            <CardHeader className="flex flex-row items-center justify-between pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground tracking-tighter">Supabase Engine</CardTitle>
-              <Database className="w-5 h-5 text-primary" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-3xl font-black tracking-tighter">Active</div>
-              <p className="text-xs text-muted-foreground mt-2 font-mono">Live Sync: Enabled</p>
-            </CardContent>
-          </Card>
-          <Card className="col-span-1 md:col-span-4 bg-card text-card-foreground border border-border shadow-sm hover:scale-[1.01] transition-all group rounded-3xl p-2">
-            <CardHeader className="flex flex-row items-center justify-between pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground tracking-tighter">GitHub Context</CardTitle>
-              <GitBranch className="w-5 h-5 text-primary" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-3xl font-black tracking-tighter">Indexed</div>
-              <p className="text-xs text-muted-foreground mt-2 font-mono">Repo: {siteConfig.name}-v2</p>
-            </CardContent>
-          </Card>
-          <Card className="col-span-1 md:col-span-4 bg-card text-card-foreground border border-border shadow-sm hover:scale-[1.01] transition-all group rounded-3xl rounded-tr-xl p-2">
-            <CardHeader className="flex flex-row items-center justify-between pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground tracking-tighter">Terminal MCP</CardTitle>
-              <Terminal className="w-5 h-5 text-primary" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-3xl font-black tracking-tighter">Ready</div>
-              <p className="text-xs text-muted-foreground mt-2 font-mono">Execution Level: 100%</p>
-            </CardContent>
-          </Card>
-        </div>
-
-        <Card className="bg-card text-card-foreground border border-border shadow-sm rounded-3xl overflow-hidden">
-          <CardContent className="p-10 md:p-14">
-            <div className="flex flex-col md:flex-row items-start gap-10">
-              <div className="w-24 h-24 rounded-3xl bg-secondary border border-border flex items-center justify-center shrink-0">
-                <Sparkles className="w-10 h-10 text-primary animate-pulse" />
-              </div>
-              <div className="space-y-6">
-                <h3 className="text-2xl md:text-3xl font-bold tracking-tighter">The Software Engineering Edge</h3>
-                <p className="text-muted-foreground text-lg leading-relaxed max-w-4xl tracking-tight">
-                  "{siteConfig.name} is designed for architects who treat AI as a first-class collaborator. By structuring your project around the <span className="text-foreground font-medium">Trinity Model</span> (DB, Code, Terminal), you reduce cognitive load and maximize throughput. Every file exists for a reason, and every reason is typed."
-                </p>
-                <div className="flex flex-wrap gap-4 pt-4">
-                  <Badge variant="secondary" className="bg-secondary text-secondary-foreground border-border py-1.5 px-4 rounded-full">Modular Architecture</Badge>
-                  <Badge variant="secondary" className="bg-secondary text-secondary-foreground border-border py-1.5 px-4 rounded-full">Type-Safe Services</Badge>
-                  <Badge variant="secondary" className="bg-secondary text-secondary-foreground border-border py-1.5 px-4 rounded-full">AI-Native Workflow</Badge>
-                </div>
-              </div>
+        {/* Logo row */}
+        <div className="h-14 flex items-center justify-between px-3 border-b border-border shrink-0">
+          <a href="/" className={`flex items-center gap-2.5 overflow-hidden ${collapsed ? "md:justify-center md:w-full" : ""}`}>
+            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-gradient-to-br from-primary to-[#5B3FE0] shadow-[0_2px_8px_rgba(124,92,255,0.4)] shrink-0">
+              <span className="text-[11px] font-black text-white">D</span>
             </div>
-          </CardContent>
-        </Card>
-      </TabsContent>
-
-
-      {/* 2. Database Tab */}
-      <TabsContent value="database" className="space-y-6 animate-in slide-in-from-bottom-2 duration-500">
-        <div className="flex flex-col gap-1">
-          <h2 className="text-2xl font-semibold text-foreground">Database Orchestration</h2>
-          <p className="text-sm text-muted-foreground">Real-time sync with <span className="font-mono text-foreground/80">public.profiles</span></p>
-        </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {displayProfiles.length > 0 ? (
-            displayProfiles.map((p: any, i: number) => (
-              <Card key={i} className="bg-card text-card-foreground border border-border hover:bg-card/90 transition-all group relative shadow-sm rounded-3xl">
-                <CardHeader className="flex flex-row items-center gap-4 pb-4">
-                  <div className="w-10 h-10 rounded-lg bg-secondary flex items-center justify-center shrink-0">
-                    <User className="w-5 h-5 text-muted-foreground" />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <CardTitle className="text-base truncate">{p.email || 'Anonymous'}</CardTitle>
-                    <CardDescription className="text-[10px] font-mono uppercase tracking-widest">{p.role || 'user'}</CardDescription>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="h-1 w-full bg-secondary rounded-full overflow-hidden">
-                    <div className={`h-full ${p.role === 'admin' ? 'bg-primary' : 'bg-primary/50'} w-3/4`}></div>
-                  </div>
-                  <div className="flex justify-between text-[10px] font-mono text-muted-foreground">
-                    <span>Integrity</span>
-                    <span>99.9%</span>
-                  </div>
-                </CardContent>
-              </Card>
-            ))
-          ) : (
-            <div className="col-span-full py-20 bg-secondary border border-dashed border-border rounded-3xl flex flex-col items-center text-center">
-              <Database className="w-12 h-12 text-muted-foreground mb-4" />
-              <p className="text-muted-foreground font-mono">No database records found.</p>
-            </div>
+            <span className={`text-sm font-bold tracking-tight text-foreground whitespace-nowrap ${collapsed ? "md:hidden" : ""}`}>
+              {siteConfig.name}
+            </span>
+          </a>
+          {/* Mobile close */}
+          <button onClick={() => setSidebarOpen(false)} className="md:hidden p-1 text-muted-foreground hover:text-foreground rounded-md">
+            <X className="w-4 h-4" />
+          </button>
+          {/* Desktop collapse */}
+          {!collapsed && (
+            <button onClick={() => setCollapsed(true)} className="hidden md:flex p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors">
+              <PanelLeftClose className="w-4 h-4" />
+            </button>
           )}
         </div>
 
-        {isFetchingNextPage && (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-6">
-            <BentoSkeleton />
-            <BentoSkeleton />
-            <BentoSkeleton />
-          </div>
+        {/* Expand when collapsed */}
+        {collapsed && (
+          <button onClick={() => setCollapsed(false)} className="hidden md:flex items-center justify-center h-10 w-full text-muted-foreground hover:text-foreground hover:bg-muted transition-colors">
+            <PanelLeft className="w-4 h-4" />
+          </button>
         )}
 
-        <div ref={ref} className="h-4 w-full mt-4 flex items-center justify-center" />
-      </TabsContent>
+        {/* Nav */}
+        <nav className="flex-1 overflow-y-auto p-2 space-y-0.5">
+          {!collapsed && (
+            <p className="px-3 py-1.5 text-[10px] font-semibold text-muted-foreground uppercase tracking-widest">
+              Main
+            </p>
+          )}
+          {NAV_MAIN.map(({ id, label, icon: Icon }) => {
+            const isActive = activeTab === id
+            return (
+              <button
+                key={id}
+                onClick={() => setTab(id)}
+                title={collapsed ? label : undefined}
+                className={`w-full flex items-center gap-3 rounded-lg text-[13px] transition-colors
+                  ${collapsed ? "md:justify-center px-0 py-2.5" : "px-3 py-2"}
+                  ${isActive
+                    ? "bg-primary/10 text-primary font-medium"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                  }`}
+              >
+                <Icon className="w-4 h-4 shrink-0" strokeWidth={1.5} />
+                <span className={collapsed ? "md:hidden" : ""}>{label}</span>
+              </button>
+            )
+          })}
+        </nav>
 
-      {/* 3. Code Tab */}
-      <TabsContent value="code" className="space-y-6 animate-in slide-in-from-bottom-2 duration-500">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-          <div className="flex flex-col gap-1">
-            <h2 className="text-2xl font-semibold text-foreground">Version Control Context</h2>
-            <p className="text-sm text-muted-foreground">AI-indexed repository history and active modules</p>
+        {/* Bottom: Settings + User ───────────────────────────────── */}
+        <div className="shrink-0 border-t border-border p-2 space-y-0.5">
+          <button
+            onClick={() => setTab("settings")}
+            title={collapsed ? "Settings" : undefined}
+            className={`w-full flex items-center gap-3 rounded-lg text-[13px] transition-colors
+              ${collapsed ? "md:justify-center px-0 py-2.5" : "px-3 py-2"}
+              ${activeTab === "settings" ? "bg-primary/10 text-primary font-medium" : "text-muted-foreground hover:text-foreground hover:bg-muted"}`}
+          >
+            <Settings className="w-4 h-4 shrink-0" strokeWidth={1.5} />
+            <span className={collapsed ? "md:hidden" : ""}>Settings</span>
+          </button>
+
+          {/* User profile row */}
+          <div className="relative">
+            {userMenuOpen && (
+              <>
+                <div className="fixed inset-0 z-40" onClick={() => setUserMenuOpen(false)} />
+                <div className="absolute bottom-full left-0 mb-2 w-52 z-50 bg-card border border-border rounded-xl shadow-lg overflow-hidden">
+                  <div className="px-4 py-3 border-b border-border">
+                    <p className="text-[12px] font-bold text-foreground truncate">{displayName}</p>
+                    <p className="text-[11px] text-muted-foreground truncate mt-0.5">{user.email}</p>
+                  </div>
+                  <div className="p-1">
+                    <button
+                      onClick={() => { router.push("/"); setUserMenuOpen(false) }}
+                      className="w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-[13px] text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                    >
+                      <Home className="w-4 h-4 shrink-0" strokeWidth={1.5} />
+                      Back to Home
+                    </button>
+                    <button
+                      onClick={() => { handleSignOut(); setUserMenuOpen(false) }}
+                      className="w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-[13px] text-destructive hover:bg-destructive/10 transition-colors"
+                    >
+                      <LogOut className="w-4 h-4 shrink-0" strokeWidth={1.5} />
+                      Sign Out
+                    </button>
+                  </div>
+                </div>
+              </>
+            )}
+            <button
+              onClick={() => setUserMenuOpen(v => !v)}
+              title={collapsed ? displayName : undefined}
+              className={`w-full flex items-center gap-2.5 rounded-lg hover:bg-muted transition-colors
+                ${collapsed ? "md:justify-center px-0 py-2" : "px-3 py-2"}`}
+            >
+              <Avatar className="h-7 w-7 border border-border shrink-0">
+                <AvatarFallback className="bg-gradient-to-br from-primary to-[#5B3FE0] text-white font-black text-[10px]">
+                  {initials}
+                </AvatarFallback>
+              </Avatar>
+              <div className={`flex-1 min-w-0 text-left ${collapsed ? "md:hidden" : ""}`}>
+                <p className="text-[12px] font-semibold text-foreground truncate">{displayName}</p>
+                <p className="text-[10px] text-muted-foreground truncate">{user.email}</p>
+              </div>
+            </button>
           </div>
-          <span className="text-[10px] font-mono uppercase tracking-widest text-muted-foreground self-start sm:self-auto">
-            {repos.length} repositories indexed
-          </span>
         </div>
+      </aside>
 
-        <RepoPagination repos={repos} />
-      </TabsContent>
+      {/* ── Main content ────────────────────────────────────────────── */}
+      <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
 
-      {/* 4. Docs Tab */}
-      <TabsContent value="docs" className="space-y-8 animate-in slide-in-from-bottom-2 duration-500">
-        <div className="flex flex-col gap-1">
-          <h2 className="text-2xl font-semibold text-foreground">Internal Documentation</h2>
-          <p className="text-sm text-muted-foreground">The architectural wisdom of the {siteConfig.name} ecosystem</p>
-        </div>
+        {/* Top bar */}
+        <header className="h-14 flex items-center justify-between px-5 border-b border-border bg-background shrink-0">
+          {/* Mobile menu button */}
+          <button onClick={() => setSidebarOpen(true)} className="md:hidden p-2 -ml-2 text-muted-foreground hover:text-foreground rounded-lg hover:bg-muted transition-colors">
+            <Menu className="w-5 h-5" />
+          </button>
+          {/* Breadcrumb */}
+          <span className="text-[14px] font-medium text-foreground hidden md:block">{activeLabel}</span>
+          <div className="flex-1 md:hidden" />
+          {/* Right spacer — user is already in sidebar */}
+          <div className="w-8" />
+        </header>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {/* Scrollable content */}
+        <main className="flex-1 overflow-y-auto p-6 md:p-8">
+          {activeTab === "overview" && <OverviewTab displayName={displayName} setTab={setTab} />}
 
-          {/* Trinity Model */}
-          <Card className="bg-card text-card-foreground border border-border shadow-sm rounded-3xl">
-            <CardHeader>
-              <CardTitle className="text-lg flex items-center gap-2">
-                <Shield className="w-5 h-5 text-primary" />
-                The Trinity Model
-              </CardTitle>
-              <CardDescription>Eyes, Blueprint, and Action</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-muted-foreground leading-relaxed">
-              <ul className="space-y-2 marker:text-foreground/50">
-                <li><span className="text-foreground font-semibold">The Eyes:</span> Typed definitions that mirror your cloud database state via <code className="text-[11px] bg-secondary px-1.5 py-0.5 rounded font-mono">src/types/supabase.ts</code>.</li>
-                <li><span className="text-foreground font-semibold">The Blueprint:</span> Timestamped SQL savepoints in <code className="text-[11px] bg-secondary px-1.5 py-0.5 rounded font-mono">supabase/backups/</code> for disaster recovery.</li>
-                <li><span className="text-foreground font-semibold">The Action:</span> Pure business logic isolated in <code className="text-[11px] bg-secondary px-1.5 py-0.5 rounded font-mono">src/services/</code>, never in UI components.</li>
-              </ul>
-            </CardContent>
-          </Card>
-
-          {/* Vibe Coding Workflow */}
-          <Card className="bg-card text-card-foreground border border-border shadow-sm rounded-3xl">
-            <CardHeader>
-              <CardTitle className="text-lg flex items-center gap-2">
-                <Terminal className="w-5 h-5 text-primary" />
-                Vibe Coding Workflow
-              </CardTitle>
-              <CardDescription>How to work with the AI architect</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-muted-foreground leading-relaxed">
-              <ul className="space-y-2">
-                <li><span className="text-foreground font-semibold">1. Check Point:</span> Run <code className="text-[11px] bg-secondary px-1.5 py-0.5 rounded font-mono">npm run checkpoint</code> before big changes.</li>
-                <li><span className="text-foreground font-semibold">2. Sync Types:</span> After any schema change, run <code className="text-[11px] bg-secondary px-1.5 py-0.5 rounded font-mono">npm run update-types</code>.</li>
-                <li><span className="text-foreground font-semibold">3. Diagnostic:</span> Use the MCP Diagnostic Protocol in <code className="text-[11px] bg-secondary px-1.5 py-0.5 rounded font-mono">AGENTS.md</code> when tools disconnect.</li>
-              </ul>
-            </CardContent>
-          </Card>
-
-          {/* Password Recovery Flow */}
-          <Card className="bg-card text-card-foreground border border-border shadow-sm rounded-3xl">
-            <CardHeader>
-              <CardTitle className="text-lg flex items-center gap-2">
-                <Edit3 className="w-5 h-5 text-primary" />
-                Password Recovery
-              </CardTitle>
-              <CardDescription>Forgot password end-to-end flow</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-muted-foreground leading-relaxed">
-              <ul className="space-y-2">
-                <li><span className="text-foreground font-semibold">/forgot-password:</span> Collects email and triggers Supabase <code className="text-[11px] bg-secondary px-1.5 py-0.5 rounded font-mono">resetPasswordForEmail</code> via Gmail SMTP.</li>
-                <li><span className="text-foreground font-semibold">/reset-password:</span> Session-guarded — only renders the form if a valid Supabase auth token is present. Expired links show a clear "Link Expired" state.</li>
-                <li><span className="text-foreground font-semibold">Toasts:</span> Sonner notifications confirm every step of the flow.</li>
-              </ul>
-            </CardContent>
-          </Card>
-
-          {/* Security Settings */}
-          <Card className="bg-card text-card-foreground border border-border shadow-sm rounded-3xl">
-            <CardHeader>
-              <CardTitle className="text-lg flex items-center gap-2">
-                <Lock className="w-5 h-5 text-primary" />
-                Security Settings
-              </CardTitle>
-              <CardDescription>Re-authentication & password management</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-muted-foreground leading-relaxed">
-              <ul className="space-y-2">
-                <li><span className="text-foreground font-semibold">Re-auth Gate:</span> Dashboard password changes require the current password first — verified via a silent <code className="text-[11px] bg-secondary px-1.5 py-0.5 rounded font-mono">signInWithPassword</code> before <code className="text-[11px] bg-secondary px-1.5 py-0.5 rounded font-mono">updateUser</code>.</li>
-                <li><span className="text-foreground font-semibold">Visibility Toggles:</span> All password fields have Eye/EyeOff icons for improved UX.</li>
-                <li><span className="text-foreground font-semibold">Gmail Alert:</span> Enable the "Password Change" Supabase email template to trigger automatic Gmail security notifications on every successful update.</li>
-              </ul>
-            </CardContent>
-          </Card>
-
-          {/* Gmail SMTP */}
-          <Card className="bg-card text-card-foreground border border-border shadow-sm rounded-3xl">
-            <CardHeader>
-              <CardTitle className="text-lg flex items-center gap-2">
-                <User className="w-5 h-5 text-primary" />
-                Gmail SMTP Setup
-              </CardTitle>
-              <CardDescription>Free email authentication for production</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-muted-foreground leading-relaxed">
-              <ul className="space-y-2">
-                <li><span className="text-foreground font-semibold">App Password:</span> Enable 2-Step Verification in Google, then generate a 16-char App Password.</li>
-                <li><span className="text-foreground font-semibold">Supabase SMTP:</span> Host <code className="text-[11px] bg-secondary px-1.5 py-0.5 rounded font-mono">smtp.gmail.com</code>, Port <code className="text-[11px] bg-secondary px-1.5 py-0.5 rounded font-mono">465</code>.</li>
-                <li><span className="text-foreground font-semibold">Templates:</span> Enable "Password Change" and "Reset Password" templates in Auth → Email Templates.</li>
-              </ul>
-            </CardContent>
-          </Card>
-
-          {/* Performance */}
-          <Card className="bg-card text-card-foreground border border-border shadow-sm rounded-3xl">
-            <CardHeader>
-              <CardTitle className="text-lg flex items-center gap-2">
-                <Activity className="w-5 h-5 text-primary" />
-                Performance Stack
-              </CardTitle>
-              <CardDescription>Caching, pagination & rate limiting</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-muted-foreground leading-relaxed">
-              <ul className="space-y-2">
-                <li><span className="text-foreground font-semibold">TanStack Query:</span> Client-side caching with optimistic mutations — zero redundant fetches on tab navigation.</li>
-                <li><span className="text-foreground font-semibold">Cursor Pagination:</span> <code className="text-[11px] bg-secondary px-1.5 py-0.5 rounded font-mono">useInfiniteQuery</code> + Intersection Observer for infinite scrolling.</li>
-                <li><span className="text-foreground font-semibold">Rate Limiting:</span> Upstash Redis sliding-window via <code className="text-[11px] bg-secondary px-1.5 py-0.5 rounded font-mono">verifyRateLimit()</code> on all server actions.</li>
-              </ul>
-            </CardContent>
-          </Card>
-
-        </div>
-      </TabsContent>
-
-      {/* 5. Security Tab */}
-      <TabsContent value="security" className="animate-in slide-in-from-bottom-2 duration-500">
-        <div className="flex justify-center w-full py-6 md:py-12">
-          <Card className="bg-card text-card-foreground border border-border p-6 md:p-12 max-w-2xl w-full shadow-sm rounded-3xl relative overflow-hidden">
-            <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-primary via-blue-500 to-accent opacity-30" />
-            <SecurityForm />
-          </Card>
-        </div>
-      </TabsContent>
-
-      {/* 6. Settings Tab */}
-      <TabsContent value="settings" className="animate-in slide-in-from-bottom-2 duration-500">
-        <div className="flex justify-center w-full py-6 md:py-12">
-          <Card className="bg-card text-card-foreground border border-border p-6 md:p-12 max-w-2xl w-full shadow-sm rounded-3xl relative overflow-hidden">
-            <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-primary via-blue-500 to-accent opacity-30" />
-            <ProfileForm profile={profile} />
-          </Card>
-        </div>
-      </TabsContent>
-
-    </Tabs>
-
-
-
+          {activeTab === "pages" && (
+            <ComingSoon icon={FileText} title="Page Editor" description="Create and edit your landing pages. Add sections, customize content, and publish changes live." phase="Phase 5" />
+          )}
+          {activeTab === "leads" && (
+            <ComingSoon icon={Inbox} title="Lead Inbox" description="View all leads from your contact forms. Track inquiries and follow up with potential clients." phase="Phase 5" />
+          )}
+          {activeTab === "team" && (
+            <ComingSoon icon={Users} title="Team Management" description="Invite team members, assign roles (admin, employee), and control access to pages and content." phase="Phase 2" />
+          )}
+          {activeTab === "settings" && (
+            <ComingSoon icon={Settings} title="Settings" description="Configure your organization branding, SMTP email, domain, and notification preferences." phase="Phase 5" />
+          )}
+        </main>
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
Replaces the tab-strip DashboardShell with a professional sidebar-based SPA layout matching the attyjuan-sched reference project:

Sidebar (bg-card, border-r, collapsible):
- Brand logo from siteConfig.name at top
- PanelLeftClose / PanelLeft collapse toggle
- MAIN section label + tab nav buttons (Overview, Pages, Leads, Team)
- Bottom: Settings + user profile (avatar, name, email)
- User popup: Back to Home, Sign Out
- Mobile: slide-in overlay with backdrop + X close

Tab navigation:
- URL-synced via ?tab= query param (router.push, no full reload)
- ComingSoon panel for unbuilt tabs (shows phase label)

Overview tab:
- 'Good day, {name}.' with current date
- 4-column stat cards (Pages, Leads, Documents, Urgent)
- Two-column: Recent Activity + Quick Actions (links to other tabs)

Dashboard stub routes added:
- /dashboard/pages, /dashboard/leads, /dashboard/team, /dashboard/settings