### PR TITLE
chore: ignore supabase CLI temp files and clean up obsolete Ruflo art…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,15 +54,16 @@ next-env.d.ts
 .claude-flow/sessions/
 .claude-flow/metrics/
 .claude-flow/learning/
-.claude-flow/embeddings.json
 
 # Ruflo memory (local, session-specific, may contain sensitive context)
 .swarm/
 @ruvector.db
-ruvector.db
 
 # MCP config (contains real tokens — never commit)
 mcp.json
 
 # Screenshot for Claude basis
 /ss/*
+
+# Supabase CLI generated files (machine-specific, ephemeral)
+supabase/.temp/


### PR DESCRIPTION
…ifacts

- Add supabase/.temp/ to gitignore (machine-specific Supabase CLI ephemeral data)
- Remove stale .claude-flow/embeddings.json entry
- Remove stale ruvector.db entry

These files are generated at runtime on each machine and should not be tracked.