### PR TITLE
docs: defer Upstash Redis rate limiting to Phase 8+

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ For the full marketing/setup story, see [README.md](README.md). For deeper docs,
 - **DB / Auth**: Supabase (`@supabase/ssr`, `@supabase/supabase-js`)
 - **Styling**: Tailwind CSS v4 + Shadcn/UI primitives
 - **State / Data**: TanStack Query, React Server Components by default
-- **Rate limiting**: Upstash Redis + Ratelimit
+- **Rate limiting**: Optional (Upstash Redis, deferred to Phase 8+ — see [#23](https://github.com/Danncode10/DannFlow/issues/23))
 - **Animation**: Framer Motion
 - **Toasts**: Sonner
 - **Icons**: lucide-react


### PR DESCRIPTION
## Summary

Rate limiting infrastructure is in place but Upstash Redis is optional and deferred. The code gracefully fails open if env keys are missing, making the template usable without external dependencies.

## Changes

- Updated tech stack section in CLAUDE.md to clarify rate limiting is optional
- Added link to issue #23 tracking future integration

## Why This Matters

- Templates can now be used for local dev without Upstash setup
- Rate limiting code is future-proof (no changes needed when keys are added)
- Reduces friction for new projects

See related issue #23 for full context.