### PR TITLE
fix: add server-side auth guard layout for /login route

### DIFF
--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -1,0 +1,11 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/utils/supabase/server'
+
+export default async function LoginLayout({ children }: { children: React.ReactNode }) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (user) redirect('/dashboard')
+
+  return <>{children}</>
+}


### PR DESCRIPTION
The /login page uses 'use client' which means middleware redirects can be bypassed — the page renders in the browser before the server-side redirect fires. This layout wraps it in a Server Component that checks the session and redirects authenticated users to /dashboard before the login page ever renders.