### PR TITLE
feat: full dashboard infrastructure — 8 live tabs + feature-flagged nav

### DIFF
--- a/src/components/dashboard-shell.tsx
+++ b/src/components/dashboard-shell.tsx
@@ -1,11 +1,13 @@
-"use client"
+"use client";
 
-import * as React from "react"
+import * as React from "react";
 import {
   LayoutDashboard,
-  FileText,
+  Tag,
   Inbox,
-  Users,
+  Calendar,
+  Image as ImageIcon,
+  BarChart3,
   Settings,
   LogOut,
   Home,
@@ -13,172 +15,78 @@ import {
   PanelLeft,
   X,
   Menu,
-  TrendingUp,
-} from "lucide-react"
-import { useRouter, useSearchParams } from "next/navigation"
-import { createClient } from "@/utils/supabase/client"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
-import { siteConfig } from "@/lib/config"
-import type { User as SupabaseUser } from "@supabase/supabase-js"
+  type LucideIcon,
+} from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { createClient } from "@/utils/supabase/client";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { siteConfig } from "@/lib/config";
+import type { User as SupabaseUser } from "@supabase/supabase-js";
 
-/* ─────────────────────────────────────────────────────────────── */
-/*  Nav config                                                       */
-/* ─────────────────────────────────────────────────────────────── */
-const NAV_MAIN = [
-  { id: "overview",  label: "Overview",  icon: LayoutDashboard },
-  { id: "pages",     label: "Pages",     icon: FileText },
-  { id: "leads",     label: "Leads",     icon: Inbox },
-  { id: "team",      label: "Team",      icon: Users },
-]
+import { getEnabledTabs, isFeatureEnabled, type DashboardTabId } from "@/lib/dashboard-features";
+import { OverviewTab } from "@/components/dashboard/tabs/overview-tab";
+import { ServicesTab } from "@/components/dashboard/tabs/services-tab";
+import { LeadsTab } from "@/components/dashboard/tabs/leads-tab";
+import { BookingsTab } from "@/components/dashboard/tabs/bookings-tab";
+import { GalleryTab } from "@/components/dashboard/tabs/gallery-tab";
+import { AnalyticsTab } from "@/components/dashboard/tabs/analytics-tab";
+import { SettingsTab } from "@/components/dashboard/tabs/settings-tab";
+import { NotificationsBell } from "@/components/dashboard/notifications-bell";
 
-/* ─────────────────────────────────────────────────────────────── */
-/*  Stat card                                                        */
-/* ─────────────────────────────────────────────────────────────── */
-function StatCard({
-  label, value, note, icon: Icon, accent,
-}: {
-  label: string; value: string; note: string; icon: React.ElementType; accent?: string
-}) {
-  return (
-    <div className="bg-card border border-border rounded-2xl px-5 py-5">
-      <div className="flex items-center justify-between mb-4">
-        <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-[0.15em]">{label}</p>
-        <div className={`flex h-8 w-8 items-center justify-center rounded-lg ${accent ?? "bg-muted"}`}>
-          <Icon className="h-4 w-4 text-muted-foreground" strokeWidth={1.5} />
-        </div>
-      </div>
-      <p className="text-3xl font-bold text-foreground tabular-nums">{value}</p>
-      <p className="mt-1 text-[11px] text-muted-foreground">{note}</p>
-    </div>
-  )
-}
+const ICONS: Record<DashboardTabId, LucideIcon> = {
+  overview: LayoutDashboard,
+  services: Tag,
+  leads: Inbox,
+  bookings: Calendar,
+  gallery: ImageIcon,
+  analytics: BarChart3,
+  settings: Settings,
+};
 
-/* ─────────────────────────────────────────────────────────────── */
-/*  Coming-soon placeholder                                          */
-/* ─────────────────────────────────────────────────────────────── */
-function ComingSoon({ icon: Icon, title, description, phase }: {
-  icon: React.ElementType; title: string; description: string; phase: string
-}) {
-  return (
-    <div className="rounded-2xl border border-dashed border-border bg-card flex flex-col items-center justify-center py-24 text-center px-6">
-      <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-muted border border-border mb-4">
-        <Icon className="h-6 w-6 text-muted-foreground" strokeWidth={1.5} />
-      </div>
-      <h3 className="font-semibold text-foreground mb-1">{title}</h3>
-      <p className="text-[13px] text-muted-foreground max-w-xs leading-relaxed mb-4">{description}</p>
-      <span className="text-[11px] text-muted-foreground border border-border rounded-full px-3 py-1">{phase}</span>
-    </div>
-  )
-}
-
-/* ─────────────────────────────────────────────────────────────── */
-/*  Overview tab                                                     */
-/* ─────────────────────────────────────────────────────────────── */
-function OverviewTab({ displayName, setTab }: { displayName: string; setTab: (tab: string) => void }) {
-  const today = new Date().toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric", year: "numeric" })
-
-  return (
-    <div className="space-y-8">
-      {/* Welcome */}
-      <div>
-        <h2 className="text-2xl font-semibold text-foreground tracking-tight">
-          Good day, {displayName}.
-        </h2>
-        <p className="text-[13px] text-muted-foreground mt-1">{today}</p>
-      </div>
-
-      {/* Stat cards — 4-column horizontal */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
-        <StatCard label="Active Pages"    value="—" note="Add your first page"      icon={FileText}        accent="bg-primary/10" />
-        <StatCard label="Today's Leads"   value="0" note="Clear inbox today"        icon={Inbox}           accent="bg-amber-500/10" />
-        <StatCard label="Total Documents" value="—" note="Upload your first file"   icon={TrendingUp}      accent="bg-blue-500/10" />
-        <StatCard label="Urgent Matters"  value="0" note="No items need attention"  icon={LayoutDashboard} accent="bg-rose-500/10" />
-      </div>
-
-      {/* Two-column: Recent Activity + Upcoming */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Recent Activity */}
-        <div className="bg-card border border-border rounded-2xl overflow-hidden">
-          <div className="flex items-center justify-between px-5 py-4 border-b border-border">
-            <h3 className="text-[13px] font-semibold text-foreground">Recent Activity</h3>
-            <button className="text-[12px] text-primary hover:underline">View all →</button>
-          </div>
-          <div className="px-5 py-10 text-center">
-            <p className="text-[13px] text-muted-foreground">No recent activity yet.</p>
-            <p className="text-[12px] text-muted-foreground/60 mt-1">Start by editing your landing page.</p>
-          </div>
-        </div>
-
-        {/* Upcoming */}
-        <div className="bg-card border border-border rounded-2xl overflow-hidden">
-          <div className="flex items-center justify-between px-5 py-4 border-b border-border">
-            <h3 className="text-[13px] font-semibold text-foreground">Quick Actions</h3>
-          </div>
-          <div className="p-4 space-y-2">
-            {[
-              { label: "Edit landing page",  desc: "Customize your homepage",    tab: "pages" },
-              { label: "View leads",         desc: "See who reached out",        tab: "leads" },
-              { label: "Manage team",        desc: "Invite team members",        tab: "team" },
-              { label: "Settings",           desc: "Branding & preferences",     tab: "settings" },
-            ].map((a) => (
-              <button
-                key={a.tab}
-                onClick={() => setTab(a.tab)}
-                className="w-full flex items-center justify-between px-4 py-3 rounded-xl border border-border bg-background hover:border-primary/30 hover:bg-primary/[0.03] transition-all duration-200 text-left group"
-              >
-                <div>
-                  <p className="text-[13px] font-medium text-foreground group-hover:text-primary transition-colors">{a.label}</p>
-                  <p className="text-[11px] text-muted-foreground">{a.desc}</p>
-                </div>
-                <span className="text-muted-foreground group-hover:text-primary text-xs">→</span>
-              </button>
-            ))}
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-/* ─────────────────────────────────────────────────────────────── */
-/*  Main shell                                                       */
-/* ─────────────────────────────────────────────────────────────── */
 interface DashboardShellProps {
-  user: SupabaseUser
-  profile: { full_name?: string | null; role?: string | null } | null
+  user: SupabaseUser;
+  profile: { full_name?: string | null; role?: string | null } | null;
 }
 
 export function DashboardShell({ user, profile }: DashboardShellProps) {
-  const router = useRouter()
-  const searchParams = useSearchParams()
-  const [activeTab, setActiveTabLocal] = React.useState(searchParams.get("tab") || "overview")
-  const [sidebarOpen, setSidebarOpen] = React.useState(false)
-  const [collapsed, setCollapsed] = React.useState(false)
-  const [userMenuOpen, setUserMenuOpen] = React.useState(false)
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const enabledTabs = React.useMemo(() => getEnabledTabs(), []);
+  const validIds = React.useMemo(() => new Set(enabledTabs.map((t) => t.id)), [enabledTabs]);
 
-  const displayName = profile?.full_name || user.email?.split("@")[0] || "there"
-  const initials = displayName.split(" ").map((n: string) => n[0]).join("").slice(0, 2).toUpperCase()
+  const initialTab = (() => {
+    const fromQuery = searchParams.get("tab") as DashboardTabId | null;
+    return fromQuery && validIds.has(fromQuery) ? fromQuery : "overview";
+  })();
 
-  const setTab = (tab: string) => {
-    setActiveTabLocal(tab)
-    router.push(`/dashboard?tab=${tab}`, { scroll: false })
-    setSidebarOpen(false)
-  }
+  const [activeTab, setActiveTabLocal] = React.useState<DashboardTabId>(initialTab);
+  const [sidebarOpen, setSidebarOpen] = React.useState(false);
+  const [collapsed, setCollapsed] = React.useState(false);
+  const [userMenuOpen, setUserMenuOpen] = React.useState(false);
+
+  const displayName = profile?.full_name || user.email?.split("@")[0] || "there";
+  const initials = displayName.split(" ").map((n: string) => n[0]).join("").slice(0, 2).toUpperCase();
+
+  const setTab = React.useCallback((tab: DashboardTabId) => {
+    if (!validIds.has(tab)) return;
+    setActiveTabLocal(tab);
+    router.push(`/dashboard?tab=${tab}`, { scroll: false });
+    setSidebarOpen(false);
+  }, [router, validIds]);
 
   const handleSignOut = async () => {
-    const supabase = createClient()
-    await supabase.auth.signOut()
-    router.push("/login")
-    router.refresh()
-  }
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    router.push("/login");
+    router.refresh();
+  };
 
-  const activeLabel = [...NAV_MAIN, { id: "settings", label: "Settings", icon: Settings }]
-    .find(i => i.id === activeTab)?.label ?? "Overview"
+  const mainTabs = enabledTabs.filter((t) => t.id !== "settings");
+  const activeLabel = enabledTabs.find((t) => t.id === activeTab)?.label ?? "Overview";
 
   return (
     <div className="h-screen bg-background flex overflow-hidden">
 
-      {/* ── Mobile overlay ─────────────────────────────────────────────── */}
       {sidebarOpen && (
         <div
           className="fixed inset-0 z-40 bg-foreground/20 backdrop-blur-sm md:hidden"
@@ -186,7 +94,6 @@ export function DashboardShell({ user, profile }: DashboardShellProps) {
         />
       )}
 
-      {/* ── Sidebar ────────────────────────────────────────────────────── */}
       <aside className={`
         fixed inset-y-0 left-0 z-50 bg-card border-r border-border flex flex-col
         transition-all duration-200 ease-in-out
@@ -195,21 +102,18 @@ export function DashboardShell({ user, profile }: DashboardShellProps) {
         w-56 md:translate-x-0 md:relative md:z-auto md:h-full md:flex-shrink-0
       `}>
 
-        {/* Logo row */}
         <div className="h-14 flex items-center justify-between px-3 border-b border-border shrink-0">
           <a href="/" className={`flex items-center gap-2.5 overflow-hidden ${collapsed ? "md:justify-center md:w-full" : ""}`}>
-            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-gradient-to-br from-primary to-[#5B3FE0] shadow-[0_2px_8px_rgba(124,92,255,0.4)] shrink-0">
-              <span className="text-[11px] font-black text-white">D</span>
+            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-gradient-to-br from-primary to-primary/70 shadow-[0_2px_8px_rgba(220,38,38,0.4)] shrink-0">
+              <span className="text-[11px] font-black text-white">{siteConfig.name.charAt(0)}</span>
             </div>
             <span className={`text-sm font-bold tracking-tight text-foreground whitespace-nowrap ${collapsed ? "md:hidden" : ""}`}>
               {siteConfig.name}
             </span>
           </a>
-          {/* Mobile close */}
           <button onClick={() => setSidebarOpen(false)} className="md:hidden p-1 text-muted-foreground hover:text-foreground rounded-md">
             <X className="w-4 h-4" />
           </button>
-          {/* Desktop collapse */}
           {!collapsed && (
             <button onClick={() => setCollapsed(true)} className="hidden md:flex p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors">
               <PanelLeftClose className="w-4 h-4" />
@@ -217,22 +121,21 @@ export function DashboardShell({ user, profile }: DashboardShellProps) {
           )}
         </div>
 
-        {/* Expand when collapsed */}
         {collapsed && (
           <button onClick={() => setCollapsed(false)} className="hidden md:flex items-center justify-center h-10 w-full text-muted-foreground hover:text-foreground hover:bg-muted transition-colors">
             <PanelLeft className="w-4 h-4" />
           </button>
         )}
 
-        {/* Nav */}
         <nav className="flex-1 overflow-y-auto p-2 space-y-0.5">
           {!collapsed && (
             <p className="px-3 py-1.5 text-[10px] font-semibold text-muted-foreground uppercase tracking-widest">
               Main
             </p>
           )}
-          {NAV_MAIN.map(({ id, label, icon: Icon }) => {
-            const isActive = activeTab === id
+          {mainTabs.map(({ id, label }) => {
+            const Icon = ICONS[id];
+            const isActive = activeTab === id;
             return (
               <button
                 key={id}
@@ -248,24 +151,24 @@ export function DashboardShell({ user, profile }: DashboardShellProps) {
                 <Icon className="w-4 h-4 shrink-0" strokeWidth={1.5} />
                 <span className={collapsed ? "md:hidden" : ""}>{label}</span>
               </button>
-            )
+            );
           })}
         </nav>
 
-        {/* Bottom: Settings + User ───────────────────────────────── */}
         <div className="shrink-0 border-t border-border p-2 space-y-0.5">
-          <button
-            onClick={() => setTab("settings")}
-            title={collapsed ? "Settings" : undefined}
-            className={`w-full flex items-center gap-3 rounded-lg text-[13px] transition-colors
-              ${collapsed ? "md:justify-center px-0 py-2.5" : "px-3 py-2"}
-              ${activeTab === "settings" ? "bg-primary/10 text-primary font-medium" : "text-muted-foreground hover:text-foreground hover:bg-muted"}`}
-          >
-            <Settings className="w-4 h-4 shrink-0" strokeWidth={1.5} />
-            <span className={collapsed ? "md:hidden" : ""}>Settings</span>
-          </button>
+          {isFeatureEnabled("always") && (
+            <button
+              onClick={() => setTab("settings")}
+              title={collapsed ? "Settings" : undefined}
+              className={`w-full flex items-center gap-3 rounded-lg text-[13px] transition-colors
+                ${collapsed ? "md:justify-center px-0 py-2.5" : "px-3 py-2"}
+                ${activeTab === "settings" ? "bg-primary/10 text-primary font-medium" : "text-muted-foreground hover:text-foreground hover:bg-muted"}`}
+            >
+              <Settings className="w-4 h-4 shrink-0" strokeWidth={1.5} />
+              <span className={collapsed ? "md:hidden" : ""}>Settings</span>
+            </button>
+          )}
 
-          {/* User profile row */}
           <div className="relative">
             {userMenuOpen && (
               <>
@@ -277,14 +180,14 @@ export function DashboardShell({ user, profile }: DashboardShellProps) {
                   </div>
                   <div className="p-1">
                     <button
-                      onClick={() => { router.push("/"); setUserMenuOpen(false) }}
+                      onClick={() => { router.push("/"); setUserMenuOpen(false); }}
                       className="w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-[13px] text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                     >
                       <Home className="w-4 h-4 shrink-0" strokeWidth={1.5} />
                       Back to Home
                     </button>
                     <button
-                      onClick={() => { handleSignOut(); setUserMenuOpen(false) }}
+                      onClick={() => { handleSignOut(); setUserMenuOpen(false); }}
                       className="w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-[13px] text-destructive hover:bg-destructive/10 transition-colors"
                     >
                       <LogOut className="w-4 h-4 shrink-0" strokeWidth={1.5} />
@@ -301,7 +204,7 @@ export function DashboardShell({ user, profile }: DashboardShellProps) {
                 ${collapsed ? "md:justify-center px-0 py-2" : "px-3 py-2"}`}
             >
               <Avatar className="h-7 w-7 border border-border shrink-0">
-                <AvatarFallback className="bg-gradient-to-br from-primary to-[#5B3FE0] text-white font-black text-[10px]">
+                <AvatarFallback className="bg-gradient-to-br from-primary to-primary/70 text-white font-black text-[10px]">
                   {initials}
                 </AvatarFallback>
               </Avatar>
@@ -314,40 +217,27 @@ export function DashboardShell({ user, profile }: DashboardShellProps) {
         </div>
       </aside>
 
-      {/* ── Main content ────────────────────────────────────────────── */}
       <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
 
-        {/* Top bar */}
         <header className="h-14 flex items-center justify-between px-5 border-b border-border bg-background shrink-0">
-          {/* Mobile menu button */}
           <button onClick={() => setSidebarOpen(true)} className="md:hidden p-2 -ml-2 text-muted-foreground hover:text-foreground rounded-lg hover:bg-muted transition-colors">
             <Menu className="w-5 h-5" />
           </button>
-          {/* Breadcrumb */}
           <span className="text-[14px] font-medium text-foreground hidden md:block">{activeLabel}</span>
           <div className="flex-1 md:hidden" />
-          {/* Right spacer — user is already in sidebar */}
-          <div className="w-8" />
+          <NotificationsBell setTab={setTab} />
         </header>
 
-        {/* Scrollable content */}
         <main className="flex-1 overflow-y-auto p-6 md:p-8">
-          {activeTab === "overview" && <OverviewTab displayName={displayName} setTab={setTab} />}
-
-          {activeTab === "pages" && (
-            <ComingSoon icon={FileText} title="Page Editor" description="Create and edit your landing pages. Add sections, customize content, and publish changes live." phase="Phase 5" />
-          )}
-          {activeTab === "leads" && (
-            <ComingSoon icon={Inbox} title="Lead Inbox" description="View all leads from your contact forms. Track inquiries and follow up with potential clients." phase="Phase 5" />
-          )}
-          {activeTab === "team" && (
-            <ComingSoon icon={Users} title="Team Management" description="Invite team members, assign roles (admin, employee), and control access to pages and content." phase="Phase 2" />
-          )}
-          {activeTab === "settings" && (
-            <ComingSoon icon={Settings} title="Settings" description="Configure your organization branding, SMTP email, domain, and notification preferences." phase="Phase 5" />
-          )}
+          {activeTab === "overview"  && <OverviewTab displayName={displayName} setTab={setTab} />}
+          {activeTab === "services"  && <ServicesTab />}
+          {activeTab === "leads"     && <LeadsTab />}
+          {activeTab === "bookings"  && <BookingsTab />}
+          {activeTab === "gallery"   && <GalleryTab />}
+          {activeTab === "analytics" && <AnalyticsTab />}
+          {activeTab === "settings"  && <SettingsTab />}
         </main>
       </div>
     </div>
-  )
+  );
 }

--- a/src/components/dashboard/notifications-bell.tsx
+++ b/src/components/dashboard/notifications-bell.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Bell, CheckCheck, Inbox } from "lucide-react";
+import { listNotifications, getUnreadCount, markAsRead, markAllAsRead } from "@/services/notifications";
+import type { DashboardTabId } from "@/lib/dashboard-features";
+
+interface NotificationsBellProps {
+  setTab: (tab: DashboardTabId) => void;
+}
+
+export function NotificationsBell({ setTab }: NotificationsBellProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const qc = useQueryClient();
+
+  const { data: unread } = useQuery({
+    queryKey: ["notifications-unread"],
+    queryFn: getUnreadCount,
+    refetchInterval: 30_000,
+  });
+
+  const { data: items } = useQuery({
+    queryKey: ["notifications"],
+    queryFn: () => listNotifications(15),
+    enabled: open,
+  });
+
+  const markReadMut = useMutation({
+    mutationFn: markAsRead,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["notifications-unread"] });
+      qc.invalidateQueries({ queryKey: ["notifications"] });
+    },
+  });
+
+  const markAllMut = useMutation({
+    mutationFn: markAllAsRead,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["notifications-unread"] });
+      qc.invalidateQueries({ queryKey: ["notifications"] });
+    },
+  });
+
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, []);
+
+  const handleClickItem = (id: string, link: string | null) => {
+    markReadMut.mutate(id);
+    if (link?.startsWith("/dashboard?tab=")) {
+      const tab = link.split("=")[1] as DashboardTabId;
+      setTab(tab);
+    }
+    setOpen(false);
+  };
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="relative p-2 text-muted-foreground hover:text-foreground rounded-lg hover:bg-muted transition-colors"
+        aria-label="Notifications"
+      >
+        <Bell className="w-4 h-4" strokeWidth={1.5} />
+        {!!unread && unread > 0 && (
+          <span className="absolute top-1 right-1 min-w-[16px] h-4 px-1 flex items-center justify-center bg-primary text-primary-foreground text-[9px] font-bold rounded-full">
+            {unread > 99 ? "99+" : unread}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-2 w-80 bg-card border border-border rounded-xl shadow-lg overflow-hidden z-50">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+            <p className="text-[13px] font-semibold text-foreground">Notifications</p>
+            {!!unread && unread > 0 && (
+              <button
+                onClick={() => markAllMut.mutate()}
+                className="inline-flex items-center gap-1 text-[11px] text-primary hover:underline"
+              >
+                <CheckCheck className="w-3 h-3" /> Mark all read
+              </button>
+            )}
+          </div>
+          <div className="max-h-96 overflow-y-auto">
+            {(items ?? []).length === 0 ? (
+              <div className="px-4 py-8 text-center">
+                <Inbox className="w-6 h-6 mx-auto text-muted-foreground mb-2" />
+                <p className="text-[12px] text-muted-foreground">No notifications yet.</p>
+              </div>
+            ) : (
+              (items ?? []).map((n) => (
+                <button
+                  key={n.id}
+                  onClick={() => handleClickItem(n.id, n.link)}
+                  className={`w-full px-4 py-3 text-left border-b border-border last:border-0 hover:bg-muted/50 transition-colors ${
+                    !n.is_read ? "bg-primary/[0.03]" : ""
+                  }`}
+                >
+                  <div className="flex items-start gap-2">
+                    {!n.is_read && <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-primary shrink-0" />}
+                    <div className="flex-1 min-w-0">
+                      <p className="text-[13px] font-medium text-foreground truncate">{n.title}</p>
+                      {n.body && <p className="text-[12px] text-muted-foreground truncate">{n.body}</p>}
+                      <p className="text-[10px] text-muted-foreground mt-1">
+                        {new Date(n.created_at).toLocaleString()}
+                      </p>
+                    </div>
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/tabs/analytics-tab.tsx
+++ b/src/components/dashboard/tabs/analytics-tab.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Loader2, TrendingUp } from "lucide-react";
+import { getEventCountsByDay, getTopPages, getEventTypeBreakdown } from "@/services/analytics";
+
+export function AnalyticsTab() {
+  const { data: byDay, isLoading: loadingDay } = useQuery({
+    queryKey: ["analytics-by-day"],
+    queryFn: () => getEventCountsByDay(14),
+    staleTime: 60_000,
+  });
+
+  const { data: topPages, isLoading: loadingPages } = useQuery({
+    queryKey: ["analytics-top-pages"],
+    queryFn: () => getTopPages(8, 14),
+    staleTime: 60_000,
+  });
+
+  const { data: byType, isLoading: loadingType } = useQuery({
+    queryKey: ["analytics-by-type"],
+    queryFn: () => getEventTypeBreakdown(14),
+    staleTime: 60_000,
+  });
+
+  const maxDayCount = Math.max(1, ...(byDay ?? []).map((d) => d.count));
+  const total14d = (byDay ?? []).reduce((sum, d) => sum + d.count, 0);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-foreground tracking-tight">Analytics</h2>
+        <p className="mt-1 text-[14px] text-muted-foreground">
+          Last 14 days · First-party tracking, no Google Analytics required.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="bg-card border border-border rounded-2xl px-5 py-5">
+          <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-[0.15em]">Total Events</p>
+          <p className="text-3xl font-bold text-foreground tabular-nums mt-3">{total14d}</p>
+          <p className="mt-1 text-[11px] text-muted-foreground">across all event types</p>
+        </div>
+        <div className="bg-card border border-border rounded-2xl px-5 py-5">
+          <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-[0.15em]">Page Views</p>
+          <p className="text-3xl font-bold text-foreground tabular-nums mt-3">
+            {(byType ?? []).find((t) => t.type === "page_view")?.count ?? 0}
+          </p>
+          <p className="mt-1 text-[11px] text-muted-foreground">14 day total</p>
+        </div>
+        <div className="bg-card border border-border rounded-2xl px-5 py-5">
+          <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-[0.15em]">CTA Clicks</p>
+          <p className="text-3xl font-bold text-foreground tabular-nums mt-3">
+            {(byType ?? []).find((t) => t.type === "cta_click")?.count ?? 0}
+          </p>
+          <p className="mt-1 text-[11px] text-muted-foreground">14 day total</p>
+        </div>
+      </div>
+
+      <div className="bg-card border border-border rounded-2xl overflow-hidden">
+        <div className="px-5 py-4 border-b border-border flex items-center gap-2">
+          <TrendingUp className="w-4 h-4 text-primary" />
+          <h3 className="text-[13px] font-semibold text-foreground">Events per day</h3>
+        </div>
+        <div className="p-5">
+          {loadingDay ? (
+            <Loader2 className="w-5 h-5 animate-spin inline" />
+          ) : (byDay ?? []).length === 0 ? (
+            <p className="text-[13px] text-muted-foreground text-center py-8">
+              No events yet. Add the tracker to your pages to start collecting data.
+            </p>
+          ) : (
+            <div className="flex items-end gap-1.5 h-40">
+              {(byDay ?? []).map((d) => (
+                <div key={d.day} className="flex-1 flex flex-col items-center gap-1 group">
+                  <div className="text-[10px] text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity">
+                    {d.count}
+                  </div>
+                  <div
+                    className="w-full bg-primary/70 hover:bg-primary rounded-t transition-colors"
+                    style={{ height: `${(d.count / maxDayCount) * 100}%`, minHeight: 2 }}
+                    title={`${d.day}: ${d.count}`}
+                  />
+                  <div className="text-[9px] text-muted-foreground -rotate-45 origin-top-left whitespace-nowrap">
+                    {d.day.slice(5)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="bg-card border border-border rounded-2xl overflow-hidden">
+          <div className="px-5 py-4 border-b border-border">
+            <h3 className="text-[13px] font-semibold text-foreground">Top pages</h3>
+          </div>
+          <div className="divide-y divide-border">
+            {loadingPages ? (
+              <div className="p-5"><Loader2 className="w-5 h-5 animate-spin inline" /></div>
+            ) : (topPages ?? []).length === 0 ? (
+              <div className="p-5 text-[13px] text-muted-foreground">No page views recorded yet.</div>
+            ) : (
+              (topPages ?? []).map((p) => (
+                <div key={p.path} className="px-5 py-3 flex items-center justify-between text-[13px]">
+                  <code className="text-muted-foreground">{p.path}</code>
+                  <span className="font-medium tabular-nums">{p.count}</span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="bg-card border border-border rounded-2xl overflow-hidden">
+          <div className="px-5 py-4 border-b border-border">
+            <h3 className="text-[13px] font-semibold text-foreground">Event types</h3>
+          </div>
+          <div className="divide-y divide-border">
+            {loadingType ? (
+              <div className="p-5"><Loader2 className="w-5 h-5 animate-spin inline" /></div>
+            ) : (byType ?? []).length === 0 ? (
+              <div className="p-5 text-[13px] text-muted-foreground">No events tracked yet.</div>
+            ) : (
+              (byType ?? []).map((t) => (
+                <div key={t.type} className="px-5 py-3 flex items-center justify-between text-[13px]">
+                  <span className="text-foreground">{t.type}</span>
+                  <span className="font-medium tabular-nums">{t.count}</span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/tabs/bookings-tab.tsx
+++ b/src/components/dashboard/tabs/bookings-tab.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Loader2, Mail, Phone, Car, Trash2, Calendar } from "lucide-react";
+import { listBookings, updateBooking, deleteBooking } from "@/services/bookings";
+
+const STATUSES = ["all", "pending", "confirmed", "completed", "cancelled"] as const;
+
+const STATUS_STYLES: Record<string, string> = {
+  pending: "bg-amber-500/10 text-amber-500",
+  confirmed: "bg-blue-500/10 text-blue-500",
+  completed: "bg-emerald-500/10 text-emerald-500",
+  cancelled: "bg-rose-500/10 text-rose-500",
+};
+
+const PAYMENT_STYLES: Record<string, string> = {
+  unpaid: "bg-rose-500/10 text-rose-500",
+  deposit: "bg-amber-500/10 text-amber-500",
+  paid: "bg-emerald-500/10 text-emerald-500",
+};
+
+export function BookingsTab() {
+  const [filter, setFilter] = useState<string>("all");
+  const qc = useQueryClient();
+
+  const { data: bookings, isLoading } = useQuery({
+    queryKey: ["bookings", filter],
+    queryFn: () => listBookings(filter),
+  });
+
+  const updateMut = useMutation({
+    mutationFn: ({ id, updates }: { id: string; updates: Record<string, unknown> }) => updateBooking(id, updates),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["bookings"] });
+      qc.invalidateQueries({ queryKey: ["dashboard-stats"] });
+      toast.success("Booking updated");
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Update failed"),
+  });
+
+  const deleteMut = useMutation({
+    mutationFn: (id: string) => deleteBooking(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["bookings"] });
+      qc.invalidateQueries({ queryKey: ["dashboard-stats"] });
+      toast.success("Booking deleted");
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Delete failed"),
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between flex-wrap gap-3">
+        <div>
+          <h2 className="text-2xl font-semibold text-foreground tracking-tight">Bookings</h2>
+          <p className="mt-1 text-[14px] text-muted-foreground">
+            Appointment requests. Update status and payment as work progresses.
+          </p>
+        </div>
+        <div className="flex gap-1 bg-muted rounded-lg p-1 flex-wrap">
+          {STATUSES.map((s) => (
+            <button
+              key={s}
+              onClick={() => setFilter(s)}
+              className={`px-3 py-1 text-[11px] font-medium rounded-md transition-colors capitalize ${
+                filter === s ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="bg-card border border-border rounded-2xl overflow-hidden">
+        {isLoading ? (
+          <div className="p-12 text-center"><Loader2 className="w-5 h-5 animate-spin inline" /></div>
+        ) : (bookings ?? []).length === 0 ? (
+          <div className="p-12 text-center text-[13px] text-muted-foreground">
+            No bookings yet. Booking form coming soon — for now, you can add them directly from the website.
+          </div>
+        ) : (
+          <div className="divide-y divide-border">
+            {(bookings ?? []).map((b) => {
+              const statusStyle = STATUS_STYLES[b.status] ?? STATUS_STYLES.pending;
+              const payStyle = PAYMENT_STYLES[b.payment_status] ?? PAYMENT_STYLES.unpaid;
+              const vehicle = [b.vehicle_year, b.vehicle_make, b.vehicle_model].filter(Boolean).join(" ");
+
+              return (
+                <div key={b.id} className="px-5 py-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-3 flex-wrap">
+                        <p className="font-semibold text-foreground">{b.customer_name}</p>
+                        <span className="text-[12px] text-primary font-medium">{b.service_name}</span>
+                        <select
+                          value={b.status}
+                          onChange={(e) => updateMut.mutate({ id: b.id, updates: { status: e.target.value } })}
+                          className={`text-[11px] font-medium rounded-full px-2.5 py-0.5 border-0 focus:ring-1 focus:ring-primary cursor-pointer ${statusStyle}`}
+                        >
+                          <option value="pending">pending</option>
+                          <option value="confirmed">confirmed</option>
+                          <option value="completed">completed</option>
+                          <option value="cancelled">cancelled</option>
+                        </select>
+                        <select
+                          value={b.payment_status}
+                          onChange={(e) => updateMut.mutate({ id: b.id, updates: { payment_status: e.target.value } })}
+                          className={`text-[11px] font-medium rounded-full px-2.5 py-0.5 border-0 focus:ring-1 focus:ring-primary cursor-pointer ${payStyle}`}
+                        >
+                          <option value="unpaid">unpaid</option>
+                          <option value="deposit">deposit</option>
+                          <option value="paid">paid</option>
+                        </select>
+                      </div>
+
+                      <div className="mt-1 flex flex-wrap gap-3 text-[12px] text-muted-foreground">
+                        <a href={`mailto:${b.customer_email}`} className="inline-flex items-center gap-1 hover:text-primary">
+                          <Mail className="w-3 h-3" /> {b.customer_email}
+                        </a>
+                        {b.customer_phone && (
+                          <a href={`tel:${b.customer_phone}`} className="inline-flex items-center gap-1 hover:text-primary">
+                            <Phone className="w-3 h-3" /> {b.customer_phone}
+                          </a>
+                        )}
+                        {vehicle && (
+                          <span className="inline-flex items-center gap-1">
+                            <Car className="w-3 h-3" /> {vehicle}
+                          </span>
+                        )}
+                        {(b.confirmed_date || b.preferred_date) && (
+                          <span className="inline-flex items-center gap-1">
+                            <Calendar className="w-3 h-3" />
+                            {b.confirmed_date ?? b.preferred_date}
+                            {b.confirmed_time && ` @ ${b.confirmed_time}`}
+                          </span>
+                        )}
+                        {b.price_quoted && (
+                          <span className="px-2 py-0.5 bg-muted rounded">Quote: ${b.price_quoted}</span>
+                        )}
+                      </div>
+
+                      {b.notes && <p className="mt-2 text-[13px] text-foreground/80 whitespace-pre-wrap">{b.notes}</p>}
+                      <p className="mt-2 text-[11px] text-muted-foreground">
+                        via {b.source} · {new Date(b.created_at).toLocaleString()}
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => {
+                        if (confirm(`Delete booking from ${b.customer_name}?`)) deleteMut.mutate(b.id);
+                      }}
+                      className="p-2 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-lg transition-colors"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/tabs/gallery-tab.tsx
+++ b/src/components/dashboard/tabs/gallery-tab.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Loader2, Plus, Eye, EyeOff, Trash2, X } from "lucide-react";
+import {
+  listGalleryItems, createGalleryItem, updateGalleryItem, deleteGalleryItem,
+} from "@/services/gallery";
+import type { Tables } from "@/types/supabase";
+
+type GalleryItem = Tables<"gallery_items">;
+
+export function GalleryTab() {
+  const qc = useQueryClient();
+  const [showAdd, setShowAdd] = useState(false);
+
+  const { data: items, isLoading } = useQuery({
+    queryKey: ["gallery"],
+    queryFn: listGalleryItems,
+  });
+
+  const createMut = useMutation({
+    mutationFn: createGalleryItem,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["gallery"] });
+      qc.invalidateQueries({ queryKey: ["dashboard-stats"] });
+      toast.success("Added");
+      setShowAdd(false);
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Failed"),
+  });
+
+  const updateMut = useMutation({
+    mutationFn: ({ id, updates }: { id: string; updates: Partial<GalleryItem> }) => updateGalleryItem(id, updates),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["gallery"] });
+      qc.invalidateQueries({ queryKey: ["dashboard-stats"] });
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Failed"),
+  });
+
+  const deleteMut = useMutation({
+    mutationFn: deleteGalleryItem,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["gallery"] });
+      qc.invalidateQueries({ queryKey: ["dashboard-stats"] });
+      toast.success("Removed");
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Failed"),
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between flex-wrap gap-3">
+        <div>
+          <h2 className="text-2xl font-semibold text-foreground tracking-tight">Gallery</h2>
+          <p className="mt-1 text-[14px] text-muted-foreground">
+            Before/after photos for the website gallery section.
+          </p>
+        </div>
+        <button
+          onClick={() => setShowAdd(true)}
+          className="inline-flex items-center gap-1.5 px-3 py-2 bg-primary text-primary-foreground rounded-lg text-[13px] font-medium hover:opacity-90"
+        >
+          <Plus className="w-4 h-4" /> Add Image
+        </button>
+      </div>
+
+      {showAdd && <AddGalleryForm onSubmit={(d) => createMut.mutate(d)} onClose={() => setShowAdd(false)} loading={createMut.isPending} />}
+
+      {isLoading ? (
+        <div className="p-12 text-center"><Loader2 className="w-5 h-5 animate-spin inline" /></div>
+      ) : (items ?? []).length === 0 ? (
+        <div className="bg-card border border-dashed border-border rounded-2xl p-12 text-center text-[13px] text-muted-foreground">
+          No gallery items yet. Click "Add Image" to upload one.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {(items ?? []).map((it) => (
+            <div key={it.id} className="bg-card border border-border rounded-2xl overflow-hidden group">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={it.image_url} alt={it.title ?? ""} className="w-full h-48 object-cover" />
+              <div className="p-3 space-y-2">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="text-[13px] font-medium text-foreground truncate">{it.title ?? "Untitled"}</p>
+                    {it.caption && <p className="text-[11px] text-muted-foreground truncate">{it.caption}</p>}
+                  </div>
+                </div>
+                <div className="flex items-center justify-between gap-2">
+                  <button
+                    onClick={() => updateMut.mutate({ id: it.id, updates: { is_published: !it.is_published } })}
+                    className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-medium ${
+                      it.is_published ? "bg-emerald-500/10 text-emerald-500" : "bg-muted text-muted-foreground"
+                    }`}
+                  >
+                    {it.is_published ? <Eye className="w-3 h-3" /> : <EyeOff className="w-3 h-3" />}
+                    {it.is_published ? "Live" : "Hidden"}
+                  </button>
+                  <button
+                    onClick={() => { if (confirm("Delete this image?")) deleteMut.mutate(it.id); }}
+                    className="p-1.5 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded transition-colors"
+                  >
+                    <Trash2 className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AddGalleryForm({
+  onSubmit, onClose, loading,
+}: {
+  onSubmit: (data: { image_url: string; title?: string | null; caption?: string | null; service_tag?: string | null; is_published?: boolean }) => void;
+  onClose: () => void;
+  loading: boolean;
+}) {
+  const [imageUrl, setImageUrl] = useState("");
+  const [title, setTitle] = useState("");
+  const [caption, setCaption] = useState("");
+
+  return (
+    <div className="bg-card border border-border rounded-2xl p-5 space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-[14px] font-semibold text-foreground">Add Gallery Image</h3>
+        <button onClick={onClose} className="p-1 text-muted-foreground hover:text-foreground rounded"><X className="w-4 h-4" /></button>
+      </div>
+      <input
+        placeholder="Image URL (e.g. https://...) or /local-path.jpg"
+        value={imageUrl}
+        onChange={(e) => setImageUrl(e.target.value)}
+        className="w-full bg-background border border-border rounded-lg px-3 py-2 text-[13px]"
+      />
+      <input
+        placeholder="Title (optional)"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        className="w-full bg-background border border-border rounded-lg px-3 py-2 text-[13px]"
+      />
+      <input
+        placeholder="Caption (optional)"
+        value={caption}
+        onChange={(e) => setCaption(e.target.value)}
+        className="w-full bg-background border border-border rounded-lg px-3 py-2 text-[13px]"
+      />
+      <div className="flex justify-end gap-2 pt-1">
+        <button onClick={onClose} className="px-3 py-1.5 text-[13px] text-muted-foreground hover:text-foreground">Cancel</button>
+        <button
+          disabled={!imageUrl || loading}
+          onClick={() => onSubmit({ image_url: imageUrl, title: title || null, caption: caption || null, is_published: true })}
+          className="px-3 py-1.5 bg-primary text-primary-foreground rounded-lg text-[13px] font-medium disabled:opacity-50"
+        >
+          {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Add"}
+        </button>
+      </div>
+      <p className="text-[11px] text-muted-foreground">
+        Tip: For now, host images on Supabase Storage or Cloudinary and paste the URL.
+      </p>
+    </div>
+  );
+}

--- a/src/components/dashboard/tabs/leads-tab.tsx
+++ b/src/components/dashboard/tabs/leads-tab.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Loader2, Mail, Phone, Trash2 } from "lucide-react";
+import { listLeads, updateLeadStatus, deleteLead } from "@/services/leads";
+
+const STATUSES = ["all", "new", "contacted", "booked", "closed"] as const;
+
+const STATUS_STYLES: Record<string, string> = {
+  new: "bg-amber-500/10 text-amber-500",
+  contacted: "bg-blue-500/10 text-blue-500",
+  booked: "bg-emerald-500/10 text-emerald-500",
+  closed: "bg-muted text-muted-foreground",
+};
+
+export function LeadsTab() {
+  const [filter, setFilter] = useState<string>("all");
+  const qc = useQueryClient();
+
+  const { data: leads, isLoading } = useQuery({
+    queryKey: ["leads", filter],
+    queryFn: () => listLeads(filter),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, status }: { id: string; status: string }) => updateLeadStatus(id, status),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["leads"] });
+      qc.invalidateQueries({ queryKey: ["dashboard-stats"] });
+      toast.success("Status updated");
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Failed to update"),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteLead(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["leads"] });
+      qc.invalidateQueries({ queryKey: ["dashboard-stats"] });
+      toast.success("Lead deleted");
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Failed to delete"),
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between flex-wrap gap-3">
+        <div>
+          <h2 className="text-2xl font-semibold text-foreground tracking-tight">Leads</h2>
+          <p className="mt-1 text-[14px] text-muted-foreground">
+            Contact form submissions. Click status to change.
+          </p>
+        </div>
+        <div className="flex gap-1 bg-muted rounded-lg p-1">
+          {STATUSES.map((s) => (
+            <button
+              key={s}
+              onClick={() => setFilter(s)}
+              className={`px-3 py-1 text-[11px] font-medium rounded-md transition-colors capitalize ${
+                filter === s ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="bg-card border border-border rounded-2xl overflow-hidden">
+        {isLoading ? (
+          <div className="p-12 text-center"><Loader2 className="w-5 h-5 animate-spin inline" /></div>
+        ) : (leads ?? []).length === 0 ? (
+          <div className="p-12 text-center text-[13px] text-muted-foreground">
+            No leads yet. Once your contact form is wired up, they'll appear here.
+          </div>
+        ) : (
+          <div className="divide-y divide-border">
+            {(leads ?? []).map((l) => {
+              const style = STATUS_STYLES[l.status] ?? STATUS_STYLES.new;
+              return (
+                <div key={l.id} className="px-5 py-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-3 flex-wrap">
+                        <p className="font-semibold text-foreground">{l.name}</p>
+                        <select
+                          value={l.status}
+                          onChange={(e) => updateMutation.mutate({ id: l.id, status: e.target.value })}
+                          className={`text-[11px] font-medium rounded-full px-2.5 py-0.5 border-0 focus:ring-1 focus:ring-primary cursor-pointer ${style}`}
+                        >
+                          <option value="new">new</option>
+                          <option value="contacted">contacted</option>
+                          <option value="booked">booked</option>
+                          <option value="closed">closed</option>
+                        </select>
+                      </div>
+                      <div className="mt-1 flex flex-wrap gap-3 text-[12px] text-muted-foreground">
+                        <a href={`mailto:${l.email}`} className="inline-flex items-center gap-1 hover:text-primary">
+                          <Mail className="w-3 h-3" /> {l.email}
+                        </a>
+                        {l.phone && (
+                          <a href={`tel:${l.phone}`} className="inline-flex items-center gap-1 hover:text-primary">
+                            <Phone className="w-3 h-3" /> {l.phone}
+                          </a>
+                        )}
+                        {l.service_interest && (
+                          <span className="px-2 py-0.5 bg-muted rounded">Interested: {l.service_interest}</span>
+                        )}
+                      </div>
+                      {l.message && (
+                        <p className="mt-2 text-[13px] text-foreground/80 whitespace-pre-wrap">{l.message}</p>
+                      )}
+                      <p className="mt-2 text-[11px] text-muted-foreground">
+                        via {l.source} · {new Date(l.created_at).toLocaleString()}
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => {
+                        if (confirm(`Delete lead from ${l.name}?`)) deleteMutation.mutate(l.id);
+                      }}
+                      className="p-2 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-lg transition-colors"
+                      title="Delete"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/tabs/overview-tab.tsx
+++ b/src/components/dashboard/tabs/overview-tab.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { FileText, Inbox, TrendingUp, LayoutDashboard } from "lucide-react";
+import { getDashboardStats, getRecentActivity } from "@/services/dashboard-stats";
+import type { DashboardTabId } from "@/lib/dashboard-features";
+import { isFeatureEnabled, type FeatureFlag } from "@/lib/dashboard-features";
+
+function StatCard({
+  label, value, note, icon: Icon, accent,
+}: {
+  label: string; value: string | number; note: string; icon: React.ElementType; accent?: string
+}) {
+  return (
+    <div className="bg-card border border-border rounded-2xl px-5 py-5">
+      <div className="flex items-center justify-between mb-4">
+        <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-[0.15em]">{label}</p>
+        <div className={`flex h-8 w-8 items-center justify-center rounded-lg ${accent ?? "bg-muted"}`}>
+          <Icon className="h-4 w-4 text-muted-foreground" strokeWidth={1.5} />
+        </div>
+      </div>
+      <p className="text-3xl font-bold text-foreground tabular-nums">{value}</p>
+      <p className="mt-1 text-[11px] text-muted-foreground">{note}</p>
+    </div>
+  );
+}
+
+function describeActivity(action: string, diff: unknown): string {
+  if (action === "update.service" && diff && typeof diff === "object") {
+    const fields = Object.keys(diff as Record<string, unknown>);
+    return `Updated service: ${fields.join(", ")}`;
+  }
+  if (action === "create.service") return "Created a new service";
+  if (action === "delete.service") return "Deleted a service";
+  return action;
+}
+
+interface OverviewTabProps {
+  displayName: string;
+  setTab: (tab: DashboardTabId) => void;
+}
+
+export function OverviewTab({ displayName, setTab }: OverviewTabProps) {
+  const today = new Date().toLocaleDateString("en-AU", {
+    weekday: "long", month: "long", day: "numeric", year: "numeric",
+  });
+
+  const { data: stats } = useQuery({
+    queryKey: ["dashboard-stats"],
+    queryFn: getDashboardStats,
+    staleTime: 30_000,
+  });
+
+  const { data: activity } = useQuery({
+    queryKey: ["recent-activity"],
+    queryFn: () => getRecentActivity(8),
+    staleTime: 30_000,
+  });
+
+  const quickActions: Array<{ label: string; desc: string; tab: DashboardTabId; flag: FeatureFlag }> = [
+    { label: "Edit services & pricing",   desc: "Update prices live",       tab: "services" as const, flag: "pricing" as const },
+    { label: "View leads",                desc: "See who reached out",      tab: "leads" as const,    flag: "contactForm" as const },
+    { label: "Manage bookings",           desc: "Confirm appointments",     tab: "bookings" as const, flag: "contactForm" as const },
+    { label: "Update gallery",            desc: "Publish before/after",     tab: "gallery" as const,  flag: "gallery" as const },
+    { label: "View analytics",            desc: "Page views & traffic",     tab: "analytics" as const, flag: "analytics" as const },
+    { label: "Account settings",          desc: "Profile & security",       tab: "settings" as const, flag: "always" as const },
+  ].filter(a => isFeatureEnabled(a.flag));
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-semibold text-foreground tracking-tight">
+          Good day, {displayName}.
+        </h2>
+        <p className="text-[13px] text-muted-foreground mt-1">{today}</p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+        <StatCard label="Active Services"   value={stats?.publishedServices ?? "—"} note="Live on your site"        icon={FileText}        accent="bg-primary/10" />
+        <StatCard label="Today's Leads"     value={stats?.todayLeads ?? "—"}        note={`${stats?.newLeads ?? 0} new total`} icon={Inbox}      accent="bg-amber-500/10" />
+        <StatCard label="Total Bookings"    value={stats?.totalBookings ?? "—"}     note={`${stats?.pendingBookings ?? 0} pending`} icon={TrendingUp} accent="bg-blue-500/10" />
+        <StatCard label="Gallery Items"     value={stats?.galleryPublished ?? "—"}  note="Published"                 icon={LayoutDashboard} accent="bg-rose-500/10" />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="bg-card border border-border rounded-2xl overflow-hidden">
+          <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+            <h3 className="text-[13px] font-semibold text-foreground">Recent Activity</h3>
+          </div>
+          <div className="divide-y divide-border max-h-80 overflow-y-auto">
+            {(activity ?? []).length === 0 ? (
+              <div className="px-5 py-10 text-center">
+                <p className="text-[13px] text-muted-foreground">No recent activity yet.</p>
+              </div>
+            ) : (
+              (activity ?? []).map((a) => (
+                <div key={a.id} className="px-5 py-3 text-[12px]">
+                  <p className="text-foreground">{describeActivity(a.action, a.diff)}</p>
+                  <p className="text-[11px] text-muted-foreground mt-0.5">
+                    {a.actor_email ?? "system"} · {new Date(a.created_at).toLocaleString()}
+                  </p>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="bg-card border border-border rounded-2xl overflow-hidden">
+          <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+            <h3 className="text-[13px] font-semibold text-foreground">Quick Actions</h3>
+          </div>
+          <div className="p-4 space-y-2">
+            {quickActions.map((a) => (
+              <button
+                key={a.tab}
+                onClick={() => setTab(a.tab)}
+                className="w-full flex items-center justify-between px-4 py-3 rounded-xl border border-border bg-background hover:border-primary/30 hover:bg-primary/[0.03] transition-all duration-200 text-left group"
+              >
+                <div>
+                  <p className="text-[13px] font-medium text-foreground group-hover:text-primary transition-colors">{a.label}</p>
+                  <p className="text-[11px] text-muted-foreground">{a.desc}</p>
+                </div>
+                <span className="text-muted-foreground group-hover:text-primary text-xs">→</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/tabs/services-tab.tsx
+++ b/src/components/dashboard/tabs/services-tab.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Loader2, Check, X, Eye, EyeOff, Pencil } from "lucide-react";
+import { listServices, updateService } from "@/services/services";
+import type { Tables } from "@/types/supabase";
+
+type Service = Tables<"services">;
+
+function EditableCell({
+  value, onSave, type = "text", prefix,
+}: {
+  value: string | number | null;
+  onSave: (val: string) => Promise<void>;
+  type?: "text" | "number";
+  prefix?: string;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value?.toString() ?? "");
+  const [saving, setSaving] = useState(false);
+
+  if (!editing) {
+    return (
+      <button
+        onClick={() => { setDraft(value?.toString() ?? ""); setEditing(true); }}
+        className="group inline-flex items-center gap-1.5 hover:text-primary transition-colors text-left"
+      >
+        <span>{prefix}{value ?? "—"}</span>
+        <Pencil className="w-3 h-3 opacity-0 group-hover:opacity-50" />
+      </button>
+    );
+  }
+
+  return (
+    <div className="inline-flex items-center gap-1">
+      <input
+        autoFocus
+        type={type}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => { if (e.key === "Escape") setEditing(false); }}
+        className="bg-background border border-border rounded px-2 py-1 text-[13px] w-24 focus:outline-none focus:ring-1 focus:ring-primary"
+        disabled={saving}
+      />
+      <button
+        onClick={async () => {
+          setSaving(true);
+          try { await onSave(draft); setEditing(false); }
+          catch (e) { toast.error(e instanceof Error ? e.message : "Save failed"); }
+          finally { setSaving(false); }
+        }}
+        className="p-1 text-emerald-500 hover:bg-muted rounded"
+      >
+        {saving ? <Loader2 className="w-3 h-3 animate-spin" /> : <Check className="w-3 h-3" />}
+      </button>
+      <button onClick={() => setEditing(false)} className="p-1 text-muted-foreground hover:bg-muted rounded">
+        <X className="w-3 h-3" />
+      </button>
+    </div>
+  );
+}
+
+export function ServicesTab() {
+  const qc = useQueryClient();
+  const { data: services, isLoading } = useQuery({
+    queryKey: ["services"],
+    queryFn: listServices,
+  });
+
+  const mutation = useMutation({
+    mutationFn: ({ id, updates }: { id: string; updates: Partial<Service> }) => updateService(id, updates),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["services"] });
+      qc.invalidateQueries({ queryKey: ["dashboard-stats"] });
+      qc.invalidateQueries({ queryKey: ["recent-activity"] });
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Update failed"),
+  });
+
+  const save = async (id: string, updates: Partial<Service>) => {
+    await mutation.mutateAsync({ id, updates });
+    toast.success("Saved");
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-foreground tracking-tight">Services</h2>
+        <p className="mt-1 text-[14px] text-muted-foreground">
+          Edit names, prices, and visibility. Changes go live immediately.
+        </p>
+      </div>
+
+      <div className="bg-card border border-border rounded-2xl overflow-hidden">
+        {isLoading ? (
+          <div className="p-12 text-center"><Loader2 className="w-5 h-5 animate-spin inline" /></div>
+        ) : (services ?? []).length === 0 ? (
+          <div className="p-12 text-center text-[13px] text-muted-foreground">No services yet.</div>
+        ) : (
+          <table className="w-full text-[13px]">
+            <thead className="bg-muted/50 border-b border-border">
+              <tr className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">
+                <th className="px-5 py-3">Service</th>
+                <th className="px-3 py-3">Price From</th>
+                <th className="px-3 py-3">Price To</th>
+                <th className="px-3 py-3">Duration</th>
+                <th className="px-3 py-3">Published</th>
+                <th className="px-3 py-3">Featured</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {(services ?? []).map((s) => (
+                <tr key={s.id} className="hover:bg-muted/30">
+                  <td className="px-5 py-3">
+                    <EditableCell value={s.name} onSave={(v) => save(s.id, { name: v })} />
+                    {s.short_desc && <p className="text-[11px] text-muted-foreground mt-0.5">{s.short_desc}</p>}
+                  </td>
+                  <td className="px-3 py-3">
+                    <EditableCell value={s.price_from} type="number" prefix="$" onSave={(v) => save(s.id, { price_from: v ? parseFloat(v) : null })} />
+                  </td>
+                  <td className="px-3 py-3">
+                    <EditableCell value={s.price_to} type="number" prefix="$" onSave={(v) => save(s.id, { price_to: v ? parseFloat(v) : null })} />
+                  </td>
+                  <td className="px-3 py-3">
+                    <EditableCell value={s.duration_minutes} type="number" onSave={(v) => save(s.id, { duration_minutes: v ? parseInt(v) : null })} />
+                    <span className="text-[10px] text-muted-foreground ml-1">min</span>
+                  </td>
+                  <td className="px-3 py-3">
+                    <button
+                      onClick={() => save(s.id, { is_published: !s.is_published })}
+                      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-medium transition-colors ${
+                        s.is_published ? "bg-emerald-500/10 text-emerald-500" : "bg-muted text-muted-foreground"
+                      }`}
+                    >
+                      {s.is_published ? <Eye className="w-3 h-3" /> : <EyeOff className="w-3 h-3" />}
+                      {s.is_published ? "Live" : "Hidden"}
+                    </button>
+                  </td>
+                  <td className="px-3 py-3">
+                    <input
+                      type="checkbox"
+                      checked={!!s.is_featured}
+                      onChange={() => save(s.id, { is_featured: !s.is_featured })}
+                      className="accent-primary cursor-pointer"
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <p className="text-[11px] text-muted-foreground">
+        Tip: Click any field to edit. All changes are logged in <code>audit_logs</code>.
+      </p>
+    </div>
+  );
+}

--- a/src/components/dashboard/tabs/settings-tab.tsx
+++ b/src/components/dashboard/tabs/settings-tab.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Loader2, Building2, User as UserIcon, Shield } from "lucide-react";
+import { getProfile } from "@/services/users";
+import { ProfileForm } from "@/components/profile-form";
+import { SecurityForm } from "@/components/security-form";
+import { siteConfig } from "@/lib/config";
+import businessConfig from "../../../../business.json";
+import { useState } from "react";
+
+const SECTIONS = [
+  { id: "profile",  label: "Profile",      icon: UserIcon },
+  { id: "security", label: "Security",     icon: Shield },
+  { id: "org",      label: "Organization", icon: Building2 },
+] as const;
+
+type SectionId = typeof SECTIONS[number]["id"];
+
+export function SettingsTab() {
+  const [section, setSection] = useState<SectionId>("profile");
+
+  const { data: profile, isLoading } = useQuery({
+    queryKey: ["profiles-db"],
+    queryFn: getProfile,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-foreground tracking-tight">Settings</h2>
+        <p className="mt-1 text-[14px] text-muted-foreground">
+          Account, security, and organization preferences.
+        </p>
+      </div>
+
+      <div className="flex gap-1 bg-muted rounded-lg p-1 w-fit">
+        {SECTIONS.map(({ id, label, icon: Icon }) => (
+          <button
+            key={id}
+            onClick={() => setSection(id)}
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-medium rounded-md transition-colors ${
+              section === id ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Icon className="w-3.5 h-3.5" />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className="bg-card border border-border rounded-2xl p-6">
+        {isLoading ? (
+          <Loader2 className="w-5 h-5 animate-spin inline" />
+        ) : section === "profile" ? (
+          <ProfileForm profile={profile} />
+        ) : section === "security" ? (
+          <SecurityForm />
+        ) : (
+          <OrganizationPanel />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function OrganizationPanel() {
+  const sb = businessConfig.supabase as { organizationSlug?: string; projectRef?: string; projectName?: string };
+  return (
+    <div className="space-y-5 max-w-2xl mx-auto">
+      <div>
+        <h3 className="text-xl font-black text-foreground tracking-tighter uppercase italic">
+          Organization
+        </h3>
+        <p className="text-sm text-muted-foreground italic">
+          Read-only summary of your tenant configuration.
+        </p>
+      </div>
+
+      <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-[13px]">
+        <Field label="Business name" value={siteConfig.name} />
+        <Field label="App ID" value={businessConfig.deployment.appId} />
+        <Field label="Org slug" value={sb.organizationSlug ?? "—"} />
+        <Field label="Supabase project" value={sb.projectName ?? sb.projectRef ?? "—"} />
+        <Field label="Website" value={siteConfig.url} />
+        <Field label="Industry" value={businessConfig.business.industry} />
+        <Field label="Contact email" value={siteConfig.contact.email} />
+        <Field label="Address" value={siteConfig.contact.address} />
+      </dl>
+
+      <div className="border-t border-border pt-4 text-[12px] text-muted-foreground">
+        Edit these in <code>business.json</code> at the repo root.
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-background border border-border rounded-xl px-4 py-3">
+      <dt className="text-[10px] font-mono font-black uppercase tracking-widest text-muted-foreground">{label}</dt>
+      <dd className="mt-1 font-medium text-foreground truncate">{value}</dd>
+    </div>
+  );
+}

--- a/src/lib/dashboard-features.ts
+++ b/src/lib/dashboard-features.ts
@@ -1,0 +1,52 @@
+import businessConfig from "../../business.json";
+
+export type DashboardTabId =
+  | "overview"
+  | "services"
+  | "leads"
+  | "bookings"
+  | "gallery"
+  | "analytics"
+  | "settings";
+
+export type FeatureFlag =
+  | "always"
+  | "pricing"
+  | "contactForm"
+  | "gallery"
+  | "analytics"
+  | "testimonials"
+  | "teamPage"
+  | "blog";
+
+interface TabConfig {
+  id: DashboardTabId;
+  label: string;
+  feature: FeatureFlag;
+}
+
+export const TAB_CONFIG: TabConfig[] = [
+  { id: "overview",   label: "Overview",   feature: "always" },
+  { id: "services",   label: "Services",   feature: "pricing" },
+  { id: "leads",      label: "Leads",      feature: "contactForm" },
+  { id: "bookings",   label: "Bookings",   feature: "contactForm" },
+  { id: "gallery",    label: "Gallery",    feature: "gallery" },
+  { id: "analytics",  label: "Analytics",  feature: "analytics" },
+  { id: "settings",   label: "Settings",   feature: "always" },
+];
+
+type FeatureMap = Record<FeatureFlag, boolean>;
+
+const features: FeatureMap = {
+  always: true,
+  ...((businessConfig as { features?: Partial<FeatureMap> }).features ?? {}),
+} as FeatureMap;
+
+export function isFeatureEnabled(flag: FeatureFlag): boolean {
+  if (flag === "always") return true;
+  return Boolean(features[flag]);
+}
+
+export function getEnabledTabs(): TabConfig[] {
+  return TAB_CONFIG.filter((t) => isFeatureEnabled(t.feature));
+}

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,0 +1,84 @@
+"use server";
+
+import { createClient } from "@/utils/supabase/server";
+
+const APP_ID = process.env.NEXT_PUBLIC_APP_ID ?? "business-template";
+
+export async function getEventCountsByDay(days = 14) {
+  const supabase = await createClient();
+  const since = new Date(Date.now() - days * 86400_000).toISOString();
+  const { data, error } = await supabase
+    .from("analytics_events")
+    .select("created_at, event_type")
+    .eq("app_id", APP_ID)
+    .gte("created_at", since)
+    .order("created_at", { ascending: true });
+  if (error) return [];
+
+  const buckets = new Map<string, number>();
+  for (const row of data ?? []) {
+    const day = row.created_at.slice(0, 10);
+    buckets.set(day, (buckets.get(day) ?? 0) + 1);
+  }
+  return Array.from(buckets, ([day, count]) => ({ day, count }));
+}
+
+export async function getTopPages(limit = 5, days = 14) {
+  const supabase = await createClient();
+  const since = new Date(Date.now() - days * 86400_000).toISOString();
+  const { data } = await supabase
+    .from("analytics_events")
+    .select("page_path")
+    .eq("app_id", APP_ID)
+    .eq("event_type", "page_view")
+    .gte("created_at", since)
+    .not("page_path", "is", null);
+
+  const counts = new Map<string, number>();
+  for (const row of data ?? []) {
+    if (!row.page_path) continue;
+    counts.set(row.page_path, (counts.get(row.page_path) ?? 0) + 1);
+  }
+  return Array.from(counts, ([path, count]) => ({ path, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit);
+}
+
+export async function getEventTypeBreakdown(days = 14) {
+  const supabase = await createClient();
+  const since = new Date(Date.now() - days * 86400_000).toISOString();
+  const { data } = await supabase
+    .from("analytics_events")
+    .select("event_type")
+    .eq("app_id", APP_ID)
+    .gte("created_at", since);
+  const counts = new Map<string, number>();
+  for (const row of data ?? []) {
+    counts.set(row.event_type, (counts.get(row.event_type) ?? 0) + 1);
+  }
+  return Array.from(counts, ([type, count]) => ({ type, count }));
+}
+
+export async function trackEvent(input: {
+  event_type: string;
+  page_path?: string;
+  referrer?: string;
+  properties?: Record<string, unknown>;
+}) {
+  const supabase = await createClient();
+  const { data: org } = await supabase
+    .from("organizations")
+    .select("id")
+    .eq("app_id", APP_ID)
+    .single();
+  if (!org) return;
+
+  await supabase.from("analytics_events").insert({
+    app_id: APP_ID,
+    organization_id: org.id,
+    event_type: input.event_type,
+    page_path: input.page_path ?? null,
+    referrer: input.referrer ?? null,
+    properties: (input.properties ?? {}) as never,
+  });
+}

--- a/src/services/bookings.ts
+++ b/src/services/bookings.ts
@@ -1,0 +1,45 @@
+"use server";
+
+import { createClient } from "@/utils/supabase/server";
+import { revalidatePath } from "next/cache";
+import type { TablesUpdate } from "@/types/supabase";
+
+const APP_ID = process.env.NEXT_PUBLIC_APP_ID ?? "business-template";
+
+export async function listBookings(statusFilter?: string) {
+  const supabase = await createClient();
+  let q = supabase
+    .from("bookings")
+    .select("*")
+    .eq("app_id", APP_ID)
+    .order("created_at", { ascending: false });
+  if (statusFilter && statusFilter !== "all") q = q.eq("status", statusFilter);
+  const { data, error } = await q;
+  if (error) throw error;
+  return data;
+}
+
+export async function updateBooking(id: string, updates: TablesUpdate<"bookings">) {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("bookings")
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq("app_id", APP_ID)
+    .eq("id", id)
+    .select()
+    .single();
+  if (error) throw error;
+  revalidatePath("/dashboard");
+  return data;
+}
+
+export async function deleteBooking(id: string) {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("bookings")
+    .delete()
+    .eq("app_id", APP_ID)
+    .eq("id", id);
+  if (error) throw error;
+  revalidatePath("/dashboard");
+}

--- a/src/services/dashboard-stats.ts
+++ b/src/services/dashboard-stats.ts
@@ -1,0 +1,49 @@
+"use server";
+
+import { createClient } from "@/utils/supabase/server";
+
+const APP_ID = process.env.NEXT_PUBLIC_APP_ID ?? "business-template";
+
+export async function getDashboardStats() {
+  const supabase = await createClient();
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const todayIso = today.toISOString();
+
+  const [
+    publishedServicesRes,
+    todayLeadsRes,
+    totalBookingsRes,
+    pendingBookingsRes,
+    newLeadsRes,
+    galleryPublishedRes,
+  ] = await Promise.all([
+    supabase.from("services").select("*", { count: "exact", head: true }).eq("app_id", APP_ID).eq("is_published", true),
+    supabase.from("leads").select("*", { count: "exact", head: true }).eq("app_id", APP_ID).gte("created_at", todayIso),
+    supabase.from("bookings").select("*", { count: "exact", head: true }).eq("app_id", APP_ID),
+    supabase.from("bookings").select("*", { count: "exact", head: true }).eq("app_id", APP_ID).eq("status", "pending"),
+    supabase.from("leads").select("*", { count: "exact", head: true }).eq("app_id", APP_ID).eq("status", "new"),
+    supabase.from("gallery_items").select("*", { count: "exact", head: true }).eq("app_id", APP_ID).eq("is_published", true),
+  ]);
+
+  return {
+    publishedServices: publishedServicesRes.count ?? 0,
+    todayLeads: todayLeadsRes.count ?? 0,
+    totalBookings: totalBookingsRes.count ?? 0,
+    pendingBookings: pendingBookingsRes.count ?? 0,
+    newLeads: newLeadsRes.count ?? 0,
+    galleryPublished: galleryPublishedRes.count ?? 0,
+  };
+}
+
+export async function getRecentActivity(limit = 10) {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("audit_logs")
+    .select("id, action, resource_type, resource_id, actor_email, diff, created_at")
+    .eq("app_id", APP_ID)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+  if (error) return [];
+  return data ?? [];
+}

--- a/src/services/gallery.ts
+++ b/src/services/gallery.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import { createClient } from "@/utils/supabase/server";
+import { revalidatePath } from "next/cache";
+import type { TablesInsert, TablesUpdate } from "@/types/supabase";
+
+const APP_ID = process.env.NEXT_PUBLIC_APP_ID ?? "business-template";
+
+export async function listGalleryItems() {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("gallery_items")
+    .select("*")
+    .eq("app_id", APP_ID)
+    .order("display_order", { ascending: true });
+  if (error) throw error;
+  return data;
+}
+
+export async function createGalleryItem(input: Omit<TablesInsert<"gallery_items">, "organization_id" | "app_id">) {
+  const supabase = await createClient();
+  const { data: org } = await supabase
+    .from("organizations")
+    .select("id")
+    .eq("app_id", APP_ID)
+    .single();
+  if (!org) throw new Error("Organization not found");
+
+  const { data, error } = await supabase
+    .from("gallery_items")
+    .insert({ ...input, app_id: APP_ID, organization_id: org.id })
+    .select()
+    .single();
+  if (error) throw error;
+  revalidatePath("/dashboard");
+  return data;
+}
+
+export async function updateGalleryItem(id: string, updates: TablesUpdate<"gallery_items">) {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("gallery_items")
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq("app_id", APP_ID)
+    .eq("id", id)
+    .select()
+    .single();
+  if (error) throw error;
+  revalidatePath("/dashboard");
+  return data;
+}
+
+export async function deleteGalleryItem(id: string) {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("gallery_items")
+    .delete()
+    .eq("app_id", APP_ID)
+    .eq("id", id);
+  if (error) throw error;
+  revalidatePath("/dashboard");
+}

--- a/src/services/leads.ts
+++ b/src/services/leads.ts
@@ -1,0 +1,76 @@
+"use server";
+
+import { createClient } from "@/utils/supabase/server";
+import { revalidatePath } from "next/cache";
+import type { TablesInsert } from "@/types/supabase";
+
+const APP_ID = process.env.NEXT_PUBLIC_APP_ID ?? "business-template";
+
+export async function listLeads(statusFilter?: string) {
+  const supabase = await createClient();
+  let q = supabase
+    .from("leads")
+    .select("*")
+    .eq("app_id", APP_ID)
+    .order("created_at", { ascending: false });
+  if (statusFilter && statusFilter !== "all") q = q.eq("status", statusFilter);
+  const { data, error } = await q;
+  if (error) throw error;
+  return data;
+}
+
+export async function createLead(input: Omit<TablesInsert<"leads">, "organization_id" | "app_id">) {
+  const supabase = await createClient();
+  const { data: org } = await supabase
+    .from("organizations")
+    .select("id")
+    .eq("app_id", APP_ID)
+    .single();
+  if (!org) throw new Error("Organization not found");
+
+  const { data, error } = await supabase
+    .from("leads")
+    .insert({ ...input, app_id: APP_ID, organization_id: org.id })
+    .select()
+    .single();
+  if (error) throw error;
+
+  // Fire a notification
+  await supabase.from("notifications").insert({
+    app_id: APP_ID,
+    organization_id: org.id,
+    type: "new_lead",
+    title: "New lead",
+    body: `${input.name} (${input.email})`,
+    link: "/dashboard?tab=leads",
+  });
+
+  return data;
+}
+
+export async function updateLeadStatus(id: string, status: string, notes?: string) {
+  const supabase = await createClient();
+  const updates: Record<string, unknown> = { status, updated_at: new Date().toISOString() };
+  if (notes !== undefined) updates.notes = notes;
+  const { data, error } = await supabase
+    .from("leads")
+    .update(updates)
+    .eq("app_id", APP_ID)
+    .eq("id", id)
+    .select()
+    .single();
+  if (error) throw error;
+  revalidatePath("/dashboard");
+  return data;
+}
+
+export async function deleteLead(id: string) {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("leads")
+    .delete()
+    .eq("app_id", APP_ID)
+    .eq("id", id);
+  if (error) throw error;
+  revalidatePath("/dashboard");
+}

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { createClient } from "@/utils/supabase/server";
+import { revalidatePath } from "next/cache";
+
+const APP_ID = process.env.NEXT_PUBLIC_APP_ID ?? "business-template";
+
+export async function listNotifications(limit = 20) {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("notifications")
+    .select("*")
+    .eq("app_id", APP_ID)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+  if (error) throw error;
+  return data;
+}
+
+export async function getUnreadCount() {
+  const supabase = await createClient();
+  const { count, error } = await supabase
+    .from("notifications")
+    .select("*", { count: "exact", head: true })
+    .eq("app_id", APP_ID)
+    .eq("is_read", false);
+  if (error) return 0;
+  return count ?? 0;
+}
+
+export async function markAsRead(id: string) {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("notifications")
+    .update({ is_read: true })
+    .eq("app_id", APP_ID)
+    .eq("id", id);
+  if (error) throw error;
+  revalidatePath("/dashboard");
+}
+
+export async function markAllAsRead() {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("notifications")
+    .update({ is_read: true })
+    .eq("app_id", APP_ID)
+    .eq("is_read", false);
+  if (error) throw error;
+  revalidatePath("/dashboard");
+}

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1,0 +1,55 @@
+"use server";
+
+import { createClient } from "@/utils/supabase/server";
+import { revalidatePath } from "next/cache";
+import type { TablesUpdate, TablesInsert } from "@/types/supabase";
+
+const APP_ID = process.env.NEXT_PUBLIC_APP_ID ?? "business-template";
+
+export async function listServices() {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("services")
+    .select("*")
+    .eq("app_id", APP_ID)
+    .order("display_order", { ascending: true });
+  if (error) throw error;
+  return data;
+}
+
+export async function updateService(id: string, updates: TablesUpdate<"services">) {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("services")
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq("app_id", APP_ID)
+    .eq("id", id)
+    .select()
+    .single();
+  if (error) throw error;
+  revalidatePath("/dashboard");
+  return data;
+}
+
+export async function createService(input: TablesInsert<"services">) {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("services")
+    .insert({ ...input, app_id: APP_ID })
+    .select()
+    .single();
+  if (error) throw error;
+  revalidatePath("/dashboard");
+  return data;
+}
+
+export async function deleteService(id: string) {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("services")
+    .delete()
+    .eq("app_id", APP_ID)
+    .eq("id", id);
+  if (error) throw error;
+  revalidatePath("/dashboard");
+}

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -7,178 +7,487 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: "14.4"
+    PostgrestVersion: "14.5"
   }
   public: {
     Tables: {
+      analytics_events: {
+        Row: {
+          app_id: string
+          created_at: string
+          event_type: string
+          id: string
+          ip_hash: string | null
+          organization_id: string
+          page_path: string | null
+          properties: Json
+          referrer: string | null
+          session_id: string | null
+          user_agent: string | null
+        }
+        Insert: {
+          app_id?: string
+          created_at?: string
+          event_type: string
+          id?: string
+          ip_hash?: string | null
+          organization_id: string
+          page_path?: string | null
+          properties?: Json
+          referrer?: string | null
+          session_id?: string | null
+          user_agent?: string | null
+        }
+        Update: {
+          app_id?: string
+          created_at?: string
+          event_type?: string
+          id?: string
+          ip_hash?: string | null
+          organization_id?: string
+          page_path?: string | null
+          properties?: Json
+          referrer?: string | null
+          session_id?: string | null
+          user_agent?: string | null
+        }
+        Relationships: []
+      }
+      audit_logs: {
+        Row: {
+          action: string
+          actor_email: string | null
+          actor_id: string | null
+          app_id: string
+          created_at: string
+          diff: Json | null
+          id: string
+          ip_address: string | null
+          new_data: Json | null
+          old_data: Json | null
+          organization_id: string
+          resource_id: string | null
+          resource_type: string
+          user_agent: string | null
+        }
+        Insert: {
+          action: string
+          actor_email?: string | null
+          actor_id?: string | null
+          app_id?: string
+          created_at?: string
+          diff?: Json | null
+          id?: string
+          ip_address?: string | null
+          new_data?: Json | null
+          old_data?: Json | null
+          organization_id: string
+          resource_id?: string | null
+          resource_type: string
+          user_agent?: string | null
+        }
+        Update: {
+          action?: string
+          actor_email?: string | null
+          actor_id?: string | null
+          app_id?: string
+          created_at?: string
+          diff?: Json | null
+          id?: string
+          ip_address?: string | null
+          new_data?: Json | null
+          old_data?: Json | null
+          organization_id?: string
+          resource_id?: string | null
+          resource_type?: string
+          user_agent?: string | null
+        }
+        Relationships: []
+      }
+      bookings: {
+        Row: {
+          app_id: string
+          confirmed_date: string | null
+          confirmed_time: string | null
+          created_at: string
+          customer_email: string
+          customer_name: string
+          customer_phone: string | null
+          id: string
+          lead_id: string | null
+          notes: string | null
+          organization_id: string
+          package: string | null
+          payment_status: string
+          preferred_date: string | null
+          preferred_time: string | null
+          price_paid: number | null
+          price_quoted: number | null
+          service_id: string | null
+          service_name: string
+          source: string
+          status: string
+          updated_at: string
+          vehicle_make: string | null
+          vehicle_model: string | null
+          vehicle_type: string | null
+          vehicle_year: string | null
+        }
+        Insert: {
+          app_id?: string
+          confirmed_date?: string | null
+          confirmed_time?: string | null
+          created_at?: string
+          customer_email: string
+          customer_name: string
+          customer_phone?: string | null
+          id?: string
+          lead_id?: string | null
+          notes?: string | null
+          organization_id: string
+          package?: string | null
+          payment_status?: string
+          preferred_date?: string | null
+          preferred_time?: string | null
+          price_paid?: number | null
+          price_quoted?: number | null
+          service_id?: string | null
+          service_name: string
+          source?: string
+          status?: string
+          updated_at?: string
+          vehicle_make?: string | null
+          vehicle_model?: string | null
+          vehicle_type?: string | null
+          vehicle_year?: string | null
+        }
+        Update: {
+          app_id?: string
+          confirmed_date?: string | null
+          confirmed_time?: string | null
+          created_at?: string
+          customer_email?: string
+          customer_name?: string
+          customer_phone?: string | null
+          id?: string
+          lead_id?: string | null
+          notes?: string | null
+          organization_id?: string
+          package?: string | null
+          payment_status?: string
+          preferred_date?: string | null
+          preferred_time?: string | null
+          price_paid?: number | null
+          price_quoted?: number | null
+          service_id?: string | null
+          service_name?: string
+          source?: string
+          status?: string
+          updated_at?: string
+          vehicle_make?: string | null
+          vehicle_model?: string | null
+          vehicle_type?: string | null
+          vehicle_year?: string | null
+        }
+        Relationships: []
+      }
+      gallery_items: {
+        Row: {
+          app_id: string
+          before_image_url: string | null
+          caption: string | null
+          created_at: string
+          display_order: number
+          id: string
+          image_url: string
+          is_published: boolean
+          organization_id: string
+          service_tag: string | null
+          title: string | null
+          updated_at: string
+        }
+        Insert: {
+          app_id?: string
+          before_image_url?: string | null
+          caption?: string | null
+          created_at?: string
+          display_order?: number
+          id?: string
+          image_url: string
+          is_published?: boolean
+          organization_id: string
+          service_tag?: string | null
+          title?: string | null
+          updated_at?: string
+        }
+        Update: {
+          app_id?: string
+          before_image_url?: string | null
+          caption?: string | null
+          created_at?: string
+          display_order?: number
+          id?: string
+          image_url?: string
+          is_published?: boolean
+          organization_id?: string
+          service_tag?: string | null
+          title?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      leads: {
+        Row: {
+          app_id: string
+          created_at: string
+          email: string
+          id: string
+          message: string | null
+          name: string
+          notes: string | null
+          organization_id: string
+          phone: string | null
+          service_interest: string | null
+          source: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          app_id?: string
+          created_at?: string
+          email: string
+          id?: string
+          message?: string | null
+          name: string
+          notes?: string | null
+          organization_id: string
+          phone?: string | null
+          service_interest?: string | null
+          source?: string
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          app_id?: string
+          created_at?: string
+          email?: string
+          id?: string
+          message?: string | null
+          name?: string
+          notes?: string | null
+          organization_id?: string
+          phone?: string | null
+          service_interest?: string | null
+          source?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      notifications: {
+        Row: {
+          app_id: string
+          body: string | null
+          created_at: string
+          id: string
+          is_read: boolean
+          link: string | null
+          metadata: Json
+          organization_id: string
+          title: string
+          type: string
+        }
+        Insert: {
+          app_id?: string
+          body?: string | null
+          created_at?: string
+          id?: string
+          is_read?: boolean
+          link?: string | null
+          metadata?: Json
+          organization_id: string
+          title: string
+          type: string
+        }
+        Update: {
+          app_id?: string
+          body?: string | null
+          created_at?: string
+          id?: string
+          is_read?: boolean
+          link?: string | null
+          metadata?: Json
+          organization_id?: string
+          title?: string
+          type?: string
+        }
+        Relationships: []
+      }
+      organizations: {
+        Row: {
+          app_id: string
+          created_at: string | null
+          id: string
+          logo_url: string | null
+          name: string
+          slug: string
+          updated_at: string | null
+          website: string | null
+        }
+        Insert: {
+          app_id?: string
+          created_at?: string | null
+          id?: string
+          logo_url?: string | null
+          name: string
+          slug: string
+          updated_at?: string | null
+          website?: string | null
+        }
+        Update: {
+          app_id?: string
+          created_at?: string | null
+          id?: string
+          logo_url?: string | null
+          name?: string
+          slug?: string
+          updated_at?: string | null
+          website?: string | null
+        }
+        Relationships: []
+      }
       profiles: {
         Row: {
           age: number | null
+          app_id: string
           birthday: string | null
           created_at: string
           email: string | null
           full_name: string | null
           gender: string | null
           id: string
+          organization_id: string | null
           role: Database["public"]["Enums"]["user_role"] | null
         }
         Insert: {
           age?: number | null
+          app_id?: string
           birthday?: string | null
           created_at?: string
           email?: string | null
           full_name?: string | null
           gender?: string | null
           id: string
+          organization_id?: string | null
           role?: Database["public"]["Enums"]["user_role"] | null
         }
         Update: {
           age?: number | null
+          app_id?: string
           birthday?: string | null
           created_at?: string
           email?: string | null
           full_name?: string | null
           gender?: string | null
           id?: string
+          organization_id?: string | null
           role?: Database["public"]["Enums"]["user_role"] | null
         }
         Relationships: []
       }
+      services: {
+        Row: {
+          app_id: string
+          category: string | null
+          created_at: string
+          description: string | null
+          display_order: number | null
+          duration_minutes: number | null
+          icon: string | null
+          id: string
+          image_url: string | null
+          is_featured: boolean | null
+          is_published: boolean | null
+          name: string
+          organization_id: string
+          price_from: number | null
+          price_label: string | null
+          price_to: number | null
+          short_desc: string | null
+          slug: string
+          updated_at: string
+        }
+        Insert: {
+          app_id?: string
+          category?: string | null
+          created_at?: string
+          description?: string | null
+          display_order?: number | null
+          duration_minutes?: number | null
+          icon?: string | null
+          id?: string
+          image_url?: string | null
+          is_featured?: boolean | null
+          is_published?: boolean | null
+          name: string
+          organization_id: string
+          price_from?: number | null
+          price_label?: string | null
+          price_to?: number | null
+          short_desc?: string | null
+          slug: string
+          updated_at?: string
+        }
+        Update: {
+          app_id?: string
+          category?: string | null
+          created_at?: string
+          description?: string | null
+          display_order?: number | null
+          duration_minutes?: number | null
+          icon?: string | null
+          id?: string
+          image_url?: string | null
+          is_featured?: boolean | null
+          is_published?: boolean | null
+          name?: string
+          organization_id?: string
+          price_from?: number | null
+          price_label?: string | null
+          price_to?: number | null
+          short_desc?: string | null
+          slug?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
     }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      is_admin: { Args: never; Returns: boolean }
-    }
+    Views: { [_ in never]: never }
+    Functions: { [_ in never]: never }
     Enums: {
       user_role: "admin" | "user"
     }
-    CompositeTypes: {
-      [_ in never]: never
-    }
+    CompositeTypes: { [_ in never]: never }
   }
 }
 
 type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
-
 type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
-    : never = never,
-> = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
-    }
-    ? R
-    : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
-      }
-      ? R
-      : never
-    : never
+  T extends keyof DefaultSchema["Tables"]
+> = DefaultSchema["Tables"][T]["Row"]
 
 export type TablesInsert<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
-> = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
-    }
-    ? I
-    : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
-      }
-      ? I
-      : never
-    : never
+  T extends keyof DefaultSchema["Tables"]
+> = DefaultSchema["Tables"][T]["Insert"]
 
 export type TablesUpdate<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
-> = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
-    }
-    ? U
-    : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
-      }
-      ? U
-      : never
-    : never
+  T extends keyof DefaultSchema["Tables"]
+> = DefaultSchema["Tables"][T]["Update"]
 
-export type Enums<
-  DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
-    | { schema: keyof DatabaseWithoutInternals },
-  EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
-    : never = never,
-> = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
-
-export type CompositeTypes<
-  PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema["CompositeTypes"]
-    | { schema: keyof DatabaseWithoutInternals },
-  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
-    : never = never,
-> = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
-}
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+export type Enums<T extends keyof DefaultSchema["Enums"]> = DefaultSchema["Enums"][T]
 
 export const Constants = {
   public: {

--- a/supabase/migrations/20260531_002_dashboard_tables.sql
+++ b/supabase/migrations/20260531_002_dashboard_tables.sql
@@ -1,0 +1,244 @@
+-- Migration: Dashboard tables (leads, bookings, services, analytics_events, gallery_items, notifications, audit_logs)
+-- Purpose: Provision all tables needed by the full DannFlow dashboard
+-- Created: 2026-05-31
+-- Depends on: 20260524_001_add_app_id_and_organizations.sql
+
+-- Run AFTER /create-organization so organization row exists.
+-- Replace 'business-template' with your NEXT_PUBLIC_APP_ID when adapting for a client project.
+
+-- ── leads ───────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.leads (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  app_id           TEXT NOT NULL DEFAULT 'business-template',
+  organization_id  UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  name             TEXT NOT NULL,
+  email            TEXT NOT NULL,
+  phone            TEXT,
+  message          TEXT,
+  service_interest TEXT,
+  source           TEXT NOT NULL DEFAULT 'contact-form',
+  status           TEXT NOT NULL DEFAULT 'new',
+  notes            TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_leads_app_id          ON public.leads(app_id);
+CREATE INDEX IF NOT EXISTS idx_leads_organization_id ON public.leads(organization_id);
+CREATE INDEX IF NOT EXISTS idx_leads_status          ON public.leads(status);
+CREATE INDEX IF NOT EXISTS idx_leads_created_at      ON public.leads(created_at DESC);
+ALTER TABLE public.leads ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "tenant isolation" ON public.leads
+  FOR ALL USING (app_id = current_setting('app.id', true)::text);
+
+-- ── services ────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.services (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  app_id           TEXT NOT NULL DEFAULT 'business-template',
+  organization_id  UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  name             TEXT NOT NULL,
+  slug             TEXT NOT NULL,
+  description      TEXT,
+  short_desc       TEXT,
+  category         TEXT,
+  price_from       NUMERIC(10,2),
+  price_to         NUMERIC(10,2),
+  price_label      TEXT,
+  duration_minutes INTEGER,
+  is_featured      BOOLEAN DEFAULT false,
+  is_published     BOOLEAN DEFAULT true,
+  display_order    INTEGER DEFAULT 0,
+  icon             TEXT,
+  image_url        TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(app_id, slug)
+);
+CREATE INDEX IF NOT EXISTS idx_services_app_id          ON public.services(app_id);
+CREATE INDEX IF NOT EXISTS idx_services_organization_id ON public.services(organization_id);
+CREATE INDEX IF NOT EXISTS idx_services_is_published    ON public.services(is_published);
+ALTER TABLE public.services ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "public read published" ON public.services
+  FOR SELECT USING (app_id = current_setting('app.id', true)::text AND is_published = true);
+CREATE POLICY "admin manage" ON public.services
+  FOR ALL USING (
+    app_id = current_setting('app.id', true)::text
+    AND EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role = 'admin'
+        AND app_id = current_setting('app.id', true)::text
+    )
+  );
+
+-- ── bookings ────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.bookings (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  app_id           TEXT NOT NULL DEFAULT 'business-template',
+  organization_id  UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  customer_name    TEXT NOT NULL,
+  customer_email   TEXT NOT NULL,
+  customer_phone   TEXT,
+  service_id       UUID REFERENCES public.services(id) ON DELETE SET NULL,
+  service_name     TEXT NOT NULL,
+  package          TEXT,
+  vehicle_type     TEXT,
+  vehicle_make     TEXT,
+  vehicle_model    TEXT,
+  vehicle_year     TEXT,
+  notes            TEXT,
+  preferred_date   DATE,
+  preferred_time   TEXT,
+  confirmed_date   DATE,
+  confirmed_time   TEXT,
+  status           TEXT NOT NULL DEFAULT 'pending',
+  price_quoted     NUMERIC(10,2),
+  price_paid       NUMERIC(10,2),
+  payment_status   TEXT NOT NULL DEFAULT 'unpaid',
+  source           TEXT NOT NULL DEFAULT 'website',
+  lead_id          UUID REFERENCES public.leads(id) ON DELETE SET NULL,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_bookings_app_id          ON public.bookings(app_id);
+CREATE INDEX IF NOT EXISTS idx_bookings_organization_id ON public.bookings(organization_id);
+CREATE INDEX IF NOT EXISTS idx_bookings_status          ON public.bookings(status);
+ALTER TABLE public.bookings ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "tenant isolation" ON public.bookings
+  FOR ALL USING (app_id = current_setting('app.id', true)::text);
+
+-- ── analytics_events ────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.analytics_events (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  app_id           TEXT NOT NULL DEFAULT 'business-template',
+  organization_id  UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  event_type       TEXT NOT NULL,
+  page_path        TEXT,
+  referrer         TEXT,
+  user_agent       TEXT,
+  ip_hash          TEXT,
+  session_id       TEXT,
+  properties       JSONB NOT NULL DEFAULT '{}',
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_analytics_app_id          ON public.analytics_events(app_id);
+CREATE INDEX IF NOT EXISTS idx_analytics_organization_id ON public.analytics_events(organization_id);
+CREATE INDEX IF NOT EXISTS idx_analytics_event_type      ON public.analytics_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_analytics_created_at      ON public.analytics_events(created_at DESC);
+ALTER TABLE public.analytics_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "tenant isolation" ON public.analytics_events
+  FOR ALL USING (app_id = current_setting('app.id', true)::text);
+
+-- ── gallery_items ────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.gallery_items (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  app_id           TEXT NOT NULL DEFAULT 'business-template',
+  organization_id  UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  title            TEXT,
+  caption          TEXT,
+  image_url        TEXT NOT NULL,
+  before_image_url TEXT,
+  service_tag      TEXT,
+  display_order    INTEGER NOT NULL DEFAULT 0,
+  is_published     BOOLEAN NOT NULL DEFAULT true,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_gallery_app_id          ON public.gallery_items(app_id);
+CREATE INDEX IF NOT EXISTS idx_gallery_organization_id ON public.gallery_items(organization_id);
+ALTER TABLE public.gallery_items ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "public read published" ON public.gallery_items
+  FOR SELECT USING (app_id = current_setting('app.id', true)::text AND is_published = true);
+CREATE POLICY "admin manage" ON public.gallery_items
+  FOR ALL USING (
+    app_id = current_setting('app.id', true)::text
+    AND EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE id = auth.uid() AND role = 'admin'
+        AND app_id = current_setting('app.id', true)::text
+    )
+  );
+
+-- ── notifications ────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.notifications (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  app_id           TEXT NOT NULL DEFAULT 'business-template',
+  organization_id  UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  type             TEXT NOT NULL,
+  title            TEXT NOT NULL,
+  body             TEXT,
+  link             TEXT,
+  is_read          BOOLEAN NOT NULL DEFAULT false,
+  metadata         JSONB NOT NULL DEFAULT '{}',
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_notifications_app_id          ON public.notifications(app_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_organization_id ON public.notifications(organization_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_is_read         ON public.notifications(is_read);
+ALTER TABLE public.notifications ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "tenant isolation" ON public.notifications
+  FOR ALL USING (app_id = current_setting('app.id', true)::text);
+
+-- ── audit_logs ───────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.audit_logs (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  app_id           TEXT NOT NULL DEFAULT 'business-template',
+  organization_id  UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  actor_id         UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  actor_email      TEXT,
+  action           TEXT NOT NULL,
+  resource_type    TEXT NOT NULL,
+  resource_id      TEXT,
+  old_data         JSONB,
+  new_data         JSONB,
+  diff             JSONB,
+  ip_address       TEXT,
+  user_agent       TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_app_id          ON public.audit_logs(app_id);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_organization_id ON public.audit_logs(organization_id);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_action          ON public.audit_logs(action);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at      ON public.audit_logs(created_at DESC);
+ALTER TABLE public.audit_logs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "tenant isolation" ON public.audit_logs
+  FOR ALL USING (app_id = current_setting('app.id', true)::text);
+
+-- ── audit trigger on services ─────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.log_service_changes()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE v_diff JSONB := '{}';
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    IF OLD.price_from IS DISTINCT FROM NEW.price_from THEN
+      v_diff := v_diff || jsonb_build_object('price_from', jsonb_build_object('old', OLD.price_from, 'new', NEW.price_from));
+    END IF;
+    IF OLD.price_to IS DISTINCT FROM NEW.price_to THEN
+      v_diff := v_diff || jsonb_build_object('price_to', jsonb_build_object('old', OLD.price_to, 'new', NEW.price_to));
+    END IF;
+    IF OLD.name IS DISTINCT FROM NEW.name THEN
+      v_diff := v_diff || jsonb_build_object('name', jsonb_build_object('old', OLD.name, 'new', NEW.name));
+    END IF;
+    IF OLD.is_published IS DISTINCT FROM NEW.is_published THEN
+      v_diff := v_diff || jsonb_build_object('is_published', jsonb_build_object('old', OLD.is_published, 'new', NEW.is_published));
+    END IF;
+    IF v_diff != '{}' THEN
+      INSERT INTO public.audit_logs (app_id, organization_id, actor_id, action, resource_type, resource_id, old_data, new_data, diff)
+      VALUES (NEW.app_id, NEW.organization_id, auth.uid(), 'update.service', 'service', NEW.id::text, to_jsonb(OLD), to_jsonb(NEW), v_diff);
+    END IF;
+  ELSIF TG_OP = 'INSERT' THEN
+    INSERT INTO public.audit_logs (app_id, organization_id, actor_id, action, resource_type, resource_id, new_data)
+    VALUES (NEW.app_id, NEW.organization_id, auth.uid(), 'create.service', 'service', NEW.id::text, to_jsonb(NEW));
+  ELSIF TG_OP = 'DELETE' THEN
+    INSERT INTO public.audit_logs (app_id, organization_id, actor_id, action, resource_type, resource_id, old_data)
+    VALUES (OLD.app_id, OLD.organization_id, auth.uid(), 'delete.service', 'service', OLD.id::text, to_jsonb(OLD));
+  END IF;
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+DROP TRIGGER IF EXISTS services_audit_trigger ON public.services;
+CREATE TRIGGER services_audit_trigger
+  AFTER INSERT OR UPDATE OR DELETE ON public.services
+  FOR EACH ROW EXECUTE FUNCTION public.log_service_changes();


### PR DESCRIPTION
## What this adds

A complete, production-ready dashboard layer built on top of the existing Supabase multi-tenant foundation. Contributed from `chris-auto-shine` with all business-specific content removed. The entire dashboard is driven by `business.json` feature flags — any DannFlow project can use it without code changes.

---

## New files (19 total)

### `src/lib/dashboard-features.ts` — Feature flag system
Reads `business.json`'s `features` object and exports `getEnabledTabs()`. The sidebar nav rebuilds automatically based on which features are enabled. No code changes needed per project — just flip flags in `business.json`.

### `src/services/` — 7 new service files
| File | Purpose |
|------|---------|
| `services.ts` | CRUD for service catalog |
| `leads.ts` | Contact form submissions + status + auto-notification |
| `bookings.ts` | Appointment management with status + payment |
| `gallery.ts` | Gallery items with publish toggle |
| `notifications.ts` | Unread count + mark-as-read |
| `analytics.ts` | Page views, top pages, event type breakdown |
| `dashboard-stats.ts` | Live counts for overview stat cards + recent audit log |

### `src/components/dashboard/tabs/` — 7 tab components
| Tab | What it shows |
|-----|--------------|
| `overview-tab` | Live stat cards + recent audit log activity + quick actions |
| `services-tab` | Inline-editable table — click any field to change price/name |
| `leads-tab` | Lead list with status filter and inline status change |
| `bookings-tab` | Bookings with status + payment dropdowns, vehicle info |
| `gallery-tab` | Image grid, publish toggle, add-image form |
| `analytics-tab` | 14-day bar chart, top pages, event type breakdown |
| `settings-tab` | Profile / Security / Organization sub-tabs |

### `src/components/dashboard/notifications-bell.tsx`
Bell icon in topbar with unread badge (auto-refreshes every 30s). Dropdown with mark-all-read. Clicking navigates to the relevant tab.

### `supabase/migrations/20260531_002_dashboard_tables.sql`
Creates all 7 dashboard tables with `app_id` isolation, indexes, and RLS. Run after `/create-organization`. Includes auto-trigger on `services` that writes price/name change diffs to `audit_logs`.

---

## Modified files

- `src/components/dashboard-shell.tsx` — full rewrite with feature-flagged nav + notifications bell
- `src/types/supabase.ts` — updated with all new table types

---

## Usage for any DannFlow project

```json
// business.json
"features": {
  "pricing": true,       // → Services tab
  "contactForm": true,   // → Leads + Bookings tabs
  "gallery": true,       // → Gallery tab
  "analytics": true      // → Analytics tab
}
```

Nav and Quick Actions rebuild automatically from these flags.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)