### PR TITLE
fix(auth): handle email confirmation redirect with origin-aware callback

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/utils/supabase/server'
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url)
+  const code = searchParams.get('code')
+  // `next` lets us send users to a specific page after confirming
+  // e.g. /auth/callback?next=/dashboard — defaults to /login
+  const next = searchParams.get('next') ?? '/login'
+
+  if (code) {
+    const supabase = await createClient()
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`)
+    }
+  }
+
+  // Something went wrong — send back to login with an error flag
+  return NextResponse.redirect(`${origin}/login?error=confirmation_failed`)
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -60,7 +60,7 @@ export default function AuthPage() {
           }, 800);
         }
       } else {
-        await signUpWithEmailRateLimited(email, password);
+        await signUpWithEmailRateLimited(email, password, window.location.origin);
         setSuccess(true);
         setTimeout(() => {
           toast.success('Account created!', { description: 'Check your email for confirmation.' });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,29 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+/**
+ * If a Supabase auth code lands at the root (or anywhere other than the
+ * callback route) — e.g. because the email template used a bare Site URL
+ * without a path — forward it to /auth/callback so the session can be
+ * exchanged correctly.
+ */
+export function middleware(request: NextRequest) {
+  const { pathname, searchParams } = request.nextUrl
+
+  const code = searchParams.get('code')
+  if (code && pathname !== '/auth/callback') {
+    const url = request.nextUrl.clone()
+    url.pathname = '/auth/callback'
+    // preserve `next` if it was passed, otherwise default to /login
+    if (!searchParams.get('next')) {
+      url.searchParams.set('next', '/login')
+    }
+    return NextResponse.redirect(url)
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  // Run on every path except static assets & API routes
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'],
+}

--- a/src/services/auth-server.ts
+++ b/src/services/auth-server.ts
@@ -25,7 +25,11 @@ export async function signInWithEmailRateLimited(email: string, password: string
   return { success: true, requiresMFA: false };
 }
 
-export async function signUpWithEmailRateLimited(email: string, password: string) {
+export async function signUpWithEmailRateLimited(
+  email: string,
+  password: string,
+  origin: string,
+) {
   const { success } = await verifyRateLimit(email);
   if (!success) throw new Error('Too many signup attempts. Try again in a few moments.');
 
@@ -33,6 +37,12 @@ export async function signUpWithEmailRateLimited(email: string, password: string
   const { error } = await supabase.auth.signUp({
     email,
     password,
+    options: {
+      // After user clicks the email link, Supabase will redirect here
+      // with ?code=... → our /auth/callback route exchanges it for a session
+      // → then redirects to /login (default next)
+      emailRedirectTo: `${origin}/auth/callback?next=/login`,
+    },
   });
   if (error) throw error;
   return { success: true };


### PR DESCRIPTION
## Summary

Email confirmation links were dropping users at the root (`/?code=...`) instead of authenticating them. Discovered while building [fix-pinas](https://github.com/Danncode10/fix-pinas) (downstream fork) — same bug exists upstream.

## Root cause

1. **`signUp()` had no `emailRedirectTo`** — Supabase fell back to the Site URL (just `/`), so the auth code arrived at a route with no handler.
2. **No `/auth/callback` route existed** to call `exchangeCodeForSession()`.
3. **No middleware to rescue stray `?code=` params** that landed at the wrong path.

## Fix

| File | Change |
|---|---|
| `src/app/auth/callback/route.ts` (new) | Calls `exchangeCodeForSession()`, redirects to a configurable `next` (defaults to `/login`). |
| `src/middleware.ts` (new) | Catches any `?code=` param on a non-callback path and forwards to `/auth/callback`. Rescues emails generated before this fix. |
| `src/services/auth-server.ts` | `signUpWithEmailRateLimited` now accepts `origin` and passes `${origin}/auth/callback?next=/login` as `emailRedirectTo` — works in both localhost dev and production without per-env Supabase config. |
| `src/app/login/page.tsx` | Passes `window.location.origin` to the signup call. |

## Why pass `origin` from the client?

The server action runs in a server context where the origin of the *user's browser* isn't directly available without reading request headers. Passing `window.location.origin` from the client is the simplest, most reliable approach — and it means localhost and production both work without changing the Supabase Site URL setting per environment.

## Test plan

- [x] Signup → email arrives → click link → land on `/login` signed-in (verified in fix-pinas downstream)
- [ ] After merge, smoke-test the same flow against a fresh DannFlow Supabase project
- [ ] Confirm middleware doesn't interfere with normal `?code=` use elsewhere (currently no other use)

## Supabase config note for users

After pulling this fix, projects need `http://localhost:3000/**` (and the production equivalent) added to **Authentication → URL Configuration → Redirect URLs** in the Supabase dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)