### PR TITLE
feat(sync): add dannflow.json version anchor + /update-dannflow command

### DIFF
--- a/.claude/commands/sync-to-upstream.md
+++ b/.claude/commands/sync-to-upstream.md
@@ -26,21 +26,32 @@ Because your project has **rewritten git history** (via `guide.sh init`), you ca
 
 ## Step 1 — Preflight checks
 
-1. Verify working tree is clean:
+1. **Read `dannflow.json`** to get the base commit:
+   ```bash
+   cat dannflow.json
+   ```
+   - If the file is missing, warn:
+     ```
+     ⚠️ No dannflow.json found. Cannot determine what changed since your last sync.
+     Run /update-dannflow to create a version anchor first.
+     ```
+     and stop.
+   - Show: `Base DannFlow commit: <dannflow_commit> (synced <synced_at>)`
+
+2. Verify working tree is clean:
    ```bash
    git status --porcelain
    ```
    If dirty, stop: tell the user to commit or stash first. Do not proceed over uncommitted work.
 
-2. Verify `upstream` remote exists and points to the right place:
+3. Verify `upstream` remote exists and matches `dannflow.json`'s `repo` field:
    ```bash
    git remote get-url upstream
    ```
-   Expected: `https://github.com/Danncode10/DannFlow.git` (or SSH equivalent).
    - If missing: tell the user to add it and stop.
    - If pointing elsewhere: warn loudly and ask for confirmation before continuing.
 
-3. Fetch latest upstream:
+4. Fetch latest upstream:
    ```bash
    git fetch upstream --quiet
    ```
@@ -83,10 +94,11 @@ next.config.ts
 tsconfig.json
 ```
 
-Build the candidate list:
+Build the candidate list using the `dannflow_commit` SHA from `dannflow.json` as the base — this is more precise than `upstream/main` because it reflects exactly what you last synced from, not the current tip:
 ```bash
-git diff --name-status upstream/main HEAD -- <each-scanned-path>
+git diff --name-status <dannflow_commit> HEAD -- <each-scanned-path>
 ```
+If a file changed both in upstream (since `dannflow_commit`) and locally, flag it as 🟡 REVIEW NEEDED — it may conflict.
 
 ---
 

--- a/.claude/commands/sync-upstream.md
+++ b/.claude/commands/sync-upstream.md
@@ -1,10 +1,12 @@
 ---
-description: Pull selective updates from DannFlow upstream. File-level diff is the default — commit-level cherry-pick is opt-in.
+description: Pull selective updates from DannFlow upstream. Reads dannflow.json to know your base commit. File-level diff is the default — commit-level cherry-pick is opt-in.
 ---
 
 # /sync-upstream
 
 Pull selective updates from the DannFlow upstream repo without merging or rebasing. The user's project has rewritten git history (via `guide.sh init`), so **there is no common ancestor with `upstream/main`** — a normal `git merge upstream/main` would be a disaster. This command works around that.
+
+> **Version-aware:** This command reads `dannflow.json` at the project root to know which DannFlow commit you last synced from, so it can show you only what's new since then.
 
 **Two modes** — file-level is the default and recommended:
 
@@ -24,26 +26,46 @@ The user invokes this command with optional args:
 
 ## Preflight (always run first)
 
-1. Verify `upstream` remote exists:
+1. **Read `dannflow.json`** to get the base commit:
+   ```bash
+   cat dannflow.json
+   ```
+   - If the file is missing, warn:
+     ```
+     ⚠️ No dannflow.json found. This project has no version anchor.
+     Run /update-dannflow to create one before syncing.
+     ```
+     and stop.
+   - Extract `dannflow_commit` (the SHA you last synced from) and `repo` (the upstream URL).
+   - Show the user: `Last synced from DannFlow commit: <sha> on <synced_at>`
+
+2. Verify `upstream` remote exists and matches `dannflow.json`'s `repo`:
    ```bash
    git remote get-url upstream
    ```
    - If missing, instruct the user:
      ```
-     git remote add upstream https://github.com/Danncode10/DannFlow.git
+     git remote add upstream <repo from dannflow.json>
      ```
      and stop.
+   - If it exists but doesn't match the `repo` field in `dannflow.json`, warn: "upstream remote points to a different repo than dannflow.json expects. Confirm before continuing."
 
-2. Fetch latest upstream (quiet — output is noisy):
+3. Fetch latest upstream (quiet — output is noisy):
    ```bash
    git fetch upstream --quiet
    ```
 
-3. Confirm `upstream/main` exists:
+4. Confirm `upstream/main` exists:
    ```bash
    git rev-parse --verify upstream/main
    ```
    If it doesn't, fall back to whatever default branch upstream has (`git remote show upstream | grep 'HEAD branch'`).
+
+5. **Show commit changelog** — what's new in upstream since your `dannflow_commit`:
+   ```bash
+   git log <dannflow_commit>..upstream/main --oneline --no-merges
+   ```
+   If there are no new commits, tell the user: "You're already up to date with DannFlow (at commit <sha>)." and exit.
 
 ---
 
@@ -111,7 +133,24 @@ src/prompts/features/
      - If "merge manually": copy upstream version to `<path>.upstream` next to the local file so user can diff them in their editor
    - 🗑️ DELETED: just inform the user — do NOT delete their local file unless they explicitly say to
 
-6. **After applying**, run `git status` and show what changed. Do NOT auto-commit. End with a suggested conventional commit message, e.g.:
+6. **After applying**, run `git status` and show what changed. Do NOT auto-commit.
+
+7. **Update `dannflow.json`** with the new upstream HEAD SHA:
+   ```bash
+   UPSTREAM_SHA=$(git rev-parse upstream/main)
+   SYNCED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+   ```
+   Write the updated `dannflow.json`:
+   ```json
+   {
+     "dannflow_commit": "<new upstream/main SHA>",
+     "synced_at": "<ISO timestamp>",
+     "repo": "<repo from existing dannflow.json>"
+   }
+   ```
+   Tell the user: "Updated dannflow.json: now tracking DannFlow at `<new sha>`"
+
+8. End with a suggested conventional commit message, e.g.:
    ```
    chore(sync): pull upstream updates to .claude/commands/ and SKILLS.md
    ```

--- a/.claude/commands/update-dannflow.md
+++ b/.claude/commands/update-dannflow.md
@@ -1,0 +1,191 @@
+---
+description: Auto-detect which DannFlow version this project is on and pull the latest updates from upstream. Creates dannflow.json if missing. The smart entry point for keeping any DannFlow-based project up to date.
+argument-hint: (optional --init to force-create dannflow.json from scratch)
+---
+
+# /update-dannflow
+
+The smart, zero-config entry point for updating a DannFlow-based project.
+
+- Auto-detects `dannflow.json` to find your current version anchor
+- If missing, creates one by detecting the upstream remote or asking the user
+- Shows a changelog of what's new in DannFlow since your last sync
+- Delegates to `/sync-upstream` for the actual file-level update
+
+Use this instead of `/sync-upstream` when you just want to say "make my project current."
+
+---
+
+## Step 1 — Detect project state
+
+Run these in parallel:
+
+```bash
+cat dannflow.json 2>/dev/null || echo "MISSING"
+git remote get-url upstream 2>/dev/null || echo "NO_UPSTREAM"
+git remote get-url origin 2>/dev/null || echo "NO_ORIGIN"
+```
+
+**Decision tree:**
+
+| dannflow.json | upstream remote | Action |
+|---|---|---|
+| Exists | Exists | Normal update flow (Step 2) |
+| Missing | Exists | Init flow — create dannflow.json (Step 1b) |
+| Missing | Missing | Ask user for DannFlow repo URL (Step 1c) |
+
+---
+
+### Step 1b — Init flow (dannflow.json missing, upstream exists)
+
+The project has an upstream remote but no version anchor. Find the closest matching commit:
+
+```bash
+git fetch upstream --quiet
+# Find the most recent upstream commit that exists in this project's history
+git log --oneline upstream/main | head -20
+```
+
+Because forked-and-rewritten projects have no shared history, we can't find an exact match. Instead:
+
+1. Show the user the 10 most recent upstream commits:
+   ```bash
+   git log upstream/main --oneline -10 --no-merges
+   ```
+2. Ask: "Which commit did you last sync from? Enter a SHA, or press Enter to use the current upstream HEAD (safest if you're not sure)."
+3. Use their answer (or upstream HEAD) as `dannflow_commit`.
+4. Write `dannflow.json`:
+   ```json
+   {
+     "dannflow_commit": "<chosen or upstream/main SHA>",
+     "synced_at": "<ISO timestamp now>",
+     "repo": "<git remote get-url upstream>"
+   }
+   ```
+5. Tell the user: "Created dannflow.json with base commit `<sha>`. Commit this file to lock in your version anchor."
+6. Proceed to Step 2.
+
+---
+
+### Step 1c — Full init (nothing exists)
+
+No upstream remote and no dannflow.json — this may not be a DannFlow project, or it was set up manually.
+
+1. Ask: "What is the DannFlow repo URL? (default: https://github.com/Danncode10/DannFlow)"
+2. Add the remote:
+   ```bash
+   git remote add upstream <url>
+   git fetch upstream --quiet
+   ```
+3. Continue with Step 1b.
+
+---
+
+## Step 2 — Read version anchor
+
+Parse `dannflow.json`:
+- `dannflow_commit` — the SHA you last synced from
+- `synced_at` — when you last synced
+- `repo` — the upstream DannFlow repo
+
+Show a one-line status:
+```
+DannFlow version anchor: <short-sha> (synced <synced_at>)
+Upstream repo: <repo>
+```
+
+---
+
+## Step 3 — Fetch and compare
+
+```bash
+git fetch upstream --quiet
+UPSTREAM_SHA=$(git rev-parse upstream/main)
+```
+
+Check if already up to date:
+```bash
+git log <dannflow_commit>..<UPSTREAM_SHA> --oneline --no-merges
+```
+
+- **0 commits:** Tell the user "Your project is already up to date with DannFlow. Nothing to sync." and exit.
+- **N commits:** Show the changelog:
+
+```
+📦 DannFlow Changelog — <short-base-sha>..<short-upstream-sha>
+N new commits since your last sync (<synced_at>):
+
+  abc1234  feat(commands): add /update-dannflow command
+  def5678  fix(sync): handle missing upstream remote gracefully
+  ghi9012  chore(docs): update sync-upstream preflight steps
+  ...
+
+Affected areas: .claude/commands/, SKILLS.md
+```
+
+Generate the affected areas summary:
+```bash
+git diff --name-only <dannflow_commit> upstream/main -- \
+  .claude/commands/ .claude/agents/ SKILLS.md CLAUDE.md AGENTS.md \
+  guide.sh docs/dannflow_docs/ scripts/ src/prompts/features/
+```
+
+---
+
+## Step 4 — Confirm and delegate
+
+Ask:
+```
+Apply these updates to your project? (y/n)
+- y → runs /sync-upstream in file-level mode, scoped to changed paths
+- n → exit (dannflow.json is NOT updated until you actually sync)
+```
+
+If confirmed, invoke `/sync-upstream` behavior directly (file-level mode, using the changed paths from Step 3 as the scan scope — no need to scan everything).
+
+After sync completes and the user approves the changes, update `dannflow.json`:
+```json
+{
+  "dannflow_commit": "<new upstream/main SHA>",
+  "synced_at": "<ISO timestamp now>",
+  "repo": "<repo from existing dannflow.json>"
+}
+```
+
+Tell the user:
+```
+✓ Updated dannflow.json → now tracking DannFlow at <new-short-sha>
+Commit this file along with your synced changes:
+  git add dannflow.json <synced files>
+  git commit -m "chore(sync): update DannFlow to <new-short-sha>"
+```
+
+---
+
+## --init flag
+
+If the user passes `--init`, skip Steps 2-4 and go straight to Step 1b/1c to force-recreate `dannflow.json`. Useful when:
+- The file got corrupted or accidentally deleted
+- The user wants to re-anchor to a specific commit
+- Setting up a project that was cloned without the file
+
+---
+
+## Safety rules
+
+- **Never** update `dannflow.json` without the user approving the sync first. The anchor is only meaningful if it matches what was actually applied.
+- **Never** auto-commit `dannflow.json` — always show the commit message suggestion and let the user run it.
+- If `git status` shows a dirty working tree at the start, refuse and tell the user to commit or stash first.
+- Validate that `dannflow_commit` is a real SHA before using it:
+  ```bash
+  git cat-file -t <dannflow_commit>
+  ```
+  If it's not found locally, run `git fetch upstream` first — the commit may not be in local history yet.
+
+---
+
+## See also
+
+- `/sync-upstream` — lower-level sync with full file-by-file control
+- `/sync-to-upstream` — contribute your improvements back to DannFlow
+- `/sync-commands` — audit which commands are documented vs. orphaned

--- a/dannflow.json
+++ b/dannflow.json
@@ -1,0 +1,5 @@
+{
+  "dannflow_commit": "8c6be5a4dd7402841044e771713609c716fa120a",
+  "synced_at": "2026-06-14T00:00:00Z",
+  "repo": "https://github.com/Danncode10/DannFlow"
+}


### PR DESCRIPTION
- Add dannflow.json tracking current DannFlow commit SHA and sync timestamp
- Update /sync-upstream to read dannflow.json for base commit and write it after sync
- Update /sync-to-upstream to use dannflow_commit SHA as diff base (more precise than upstream/main)
- Add new /update-dannflow command: auto-detects version, shows changelog, delegates to /sync-upstream

Closes #35