### PR TITLE
feat: add /adopt-dannflow + CI-gated feat->dev->main sync flow

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -2,7 +2,7 @@
 
 Drop `.md` files in this folder to add custom slash commands. Each file becomes `/filename`.
 
-## Planned commands
+## Available commands
 
 | Command | Purpose |
 |---|---|
@@ -23,14 +23,17 @@ Drop `.md` files in this folder to add custom slash commands. Each file becomes 
 | `/sync-commands` | Audits `.claude/commands/` and validates against `claude-workflow.md` and `./guide.sh`. Reports orphaned commands, optionally auto-patches docs. |
 | `/auto-docs` | Broader superset of `/sync-commands`. Audits commands, skills, npm scripts, env vars, tech stack, and folder structure for documentation drift. `--fix` auto-patches the safe categories. |
 | `/init-update` | Update your DannFlow project to the latest version — pull new commands, scripts, guide, skills, and more while preserving your code. Interactive menu or `--all` for one-command full update. |
-| `/sync-upstream [path|--commits [N]]` | Pull selective file or commit updates from DannFlow upstream. File-level diff is the default — safe for forked-and-rewritten repos with no common git ancestry. Opt-in commit-level cherry-pick with `--commits`. |
+| `/adopt-dannflow [--no-protect\|--force]` | Bootstrap a non-DannFlow repo into a first-class DannFlow project: detect shape, install + prove CI, write `dannflow.json`, create the `dev` branch, then run the first sync. Run once per repo. |
+| `/sync-upstream [path|--commits [N]]` | Pull selective file or commit updates from DannFlow upstream. Lands changes on a `feat/sync-*` branch → PR into `dev`. File-level diff is the default — safe for forked-and-rewritten repos with no common git ancestry. Opt-in commit-level cherry-pick with `--commits`. |
+| `/sync-to-upstream [path\|--dry-run]` | Contribute local improvements back UP to DannFlow. Classifies changes as generic vs. business-specific, then opens a clean PR into DannFlow `main`. |
+| `/update-dannflow [--init]` | Smart entry point — auto-detects your `dannflow.json` version anchor and pulls the latest upstream updates. Creates the anchor if missing. |
 | `/no-conflict` | Audits repo for conflicts between documentation (README, CLAUDE.md) and actual code — technology versions, features, commands, RLS enforcement, semantic tokens, folder structure. Reports only. |
 | `/seed <table\|all>` | Generates realistic, type-safe seed data from `src/types/supabase.ts`. Respects FK order and RLS ownership. Writes to `supabase/seeds/`. |
 | `/migrate <description>` | Wraps the full migration flow — checkpoint → apply_migration → sync-types — into one step. Plain-English description in, type-safe code out. |
 | `/seo-check [route]` | Per-route SEO audit: metadata, OG, canonical, sitemap.ts, robots.ts, JSON-LD, alt text, heading hierarchy. Reports only. |
 | `/seo-fix <route\|all>` | Active rewrite — adds missing SEO essentials. Scaffolds `sitemap.ts`, `robots.ts`, metadata blocks, JSON-LD. Plan-then-confirm. |
 | `/marketing-check [route]` | Conversion-fundamentals audit for landing/marketing pages — headline, CTA, social proof, friction, pricing legibility. Opinionated, judgement-heavy. Reports only. |
-| `/ruflo-upgrade` | Re-applies Ruflo memory + parallel-agent patterns to the 5 core commands. Safe to re-run after `/init-update`. |
+| `/ruflo-upgrade` | Re-applies Ruflo memory + parallel-agent patterns to the 8 core commands. Safe to re-run after `/init-update`. |
 | `/make-command` | Creates a new custom slash command from a plain-English description. Auto-updates documentation and proposes conflict-avoidance edits to existing commands or SKILLS.md. |
 | `/masterplan-task` | Execute a task from MASTERPLAN.md and auto-generate TEST.md verification guide. Use during development sprints for systematic, hallucination-free feature scaffolding. |
 
@@ -48,6 +51,10 @@ The prompt that Claude executes when you run /commandname.
 Use $ARGUMENTS to reference args the user typed after the command.
 ```
 
-## Status
+## Keeping this index current
 
-Empty for now. Commands will be added one at a time after planning is locked in.
+This table covers the core DannFlow commands. The folder also contains Ruflo/claude-flow
+command packs (`claude-flow-*`, plus the `agents/`, `swarm/`, `sparc/`, etc. subfolders) that
+aren't listed individually here. To reconcile this index with what's actually on disk, run
+`/auto-docs` (broad drift check) or `/sync-commands` (command-specific) — they detect orphaned
+or undocumented commands and can auto-patch.

--- a/.claude/commands/adopt-dannflow.md
+++ b/.claude/commands/adopt-dannflow.md
@@ -1,0 +1,188 @@
+---
+description: Bootstrap an existing repo into a first-class DannFlow project. Installs CI (and proves it passes), creates the dannflow.json version anchor, sets up the dev/feat branch flow, then runs the first sync from upstream.
+argument-hint: (optional --no-protect to skip branch protection, --force to re-adopt)
+---
+
+# /adopt-dannflow
+
+Turn a repo that was **never born from DannFlow** into a first-class DannFlow project — one that `/sync-upstream` and `/sync-to-upstream` can manage forever after.
+
+Run this **once** per repo. If `dannflow.json` already exists, the repo is already adopted — use `/sync-upstream` instead.
+
+> **Mental model.** DannFlow is the master template ("recipe book"). This command walks into a messy kitchen and installs the basics: the CI safety-check, the version label (`dannflow.json`), and the `dev` / `feat` branch counters. Its last step pulls the recipes in for the first time via `/sync-upstream`.
+
+## What it does (in order)
+
+1. **Preflight** — confirm clean tree, a GitHub repo, and that we're not already adopted.
+2. **Detect project shape** — package manager, Node version, which npm scripts exist.
+3. **Install CI** — drop in an auto-adjusted `ci.yml` **and prove it passes** before relying on it.
+4. **Create the version anchor** — `dannflow.json` pointing at the current DannFlow commit.
+5. **Set up the branch flow** — create `dev`, optionally protect `main`.
+6. **First sync** — hand off to `/sync-upstream` to pull the template in.
+7. **Commit** — with provenance trailers (see the spec at the bottom of this file).
+
+---
+
+## Argument parsing
+
+- `/adopt-dannflow` → full adoption flow
+- `/adopt-dannflow --no-protect` → do everything, but skip setting GitHub branch protection (create branches only)
+- `/adopt-dannflow --force` → re-run even if `dannflow.json` already exists (re-anchor / repair)
+
+---
+
+## Step 0 — Preflight (always run first)
+
+Run these in parallel:
+
+```bash
+git rev-parse --is-inside-work-tree 2>/dev/null || echo "NOT_A_REPO"
+git status --porcelain
+git remote get-url origin 2>/dev/null || echo "NO_ORIGIN"
+cat dannflow.json 2>/dev/null || echo "NO_ANCHOR"
+gh auth status 2>&1 | head -1 || echo "NO_GH"
+```
+
+Refuse and stop if:
+- **Not a git repo** → tell the user to `git init` and push to GitHub first.
+- **Dirty working tree** → tell the user to commit or stash first. Adoption touches several files; we don't want to mix it with unrelated work.
+- **No `origin`** → adoption sets up a PR/CI flow, which needs a GitHub remote. Tell the user to create the repo on GitHub and `git remote add origin ...` first.
+- **`dannflow.json` already exists** and `--force` was NOT passed → this repo is already adopted. Say: *"Already adopted (tracking DannFlow at `<sha>`). Use `/sync-upstream` to update, or `/adopt-dannflow --force` to re-anchor."* and stop.
+
+If `gh` is not authenticated, warn that branch protection and PR creation will be skipped, and continue in a degraded (local-only) mode.
+
+---
+
+## Step 1 — Detect project shape (for auto-adjust)
+
+The CI template must match the real project, so detect — **don't assume**:
+
+```bash
+# Package manager (first lockfile wins)
+ls pnpm-lock.yaml yarn.lock package-lock.json bun.lockb 2>/dev/null
+
+# Node version
+cat .nvmrc 2>/dev/null; node -p "require('./package.json').engines?.node || ''" 2>/dev/null
+
+# Which scripts actually exist
+node -p "Object.keys(require('./package.json').scripts || {}).join(', ')" 2>/dev/null
+```
+
+Record:
+- **pm** → `pnpm` | `yarn` | `npm` | `bun` (default `npm` if no lockfile)
+- **node** → from `.nvmrc` / `engines.node`, else default to the LTS the template ships (`20`)
+- **scripts** → the set actually present (`build`, `lint`, `typecheck`, `test`, …)
+
+> ⚠️ **The auto-adjust trap.** Only emit CI steps whose scripts truly exist. A `lint` job that calls a missing `npm run lint` will fail forever — and once CI is a required check, **a broken workflow means nothing can ever merge.** When in doubt, leave a step out.
+
+---
+
+## Step 2 — Install CI and PROVE it passes
+
+1. Read the template workflow from upstream (`.github/workflows/ci.yml`) — fetch it via the upstream remote (added in Step 3 if missing) or from `https://github.com/Danncode10/DannFlow`.
+2. Rewrite it for the detected shape:
+   - swap install/cache steps to the detected **pm**
+   - set the **node** version
+   - include only the jobs whose **scripts** exist
+3. Write it to `.github/workflows/ci.yml`. If one already exists, **do not overwrite** — show a diff and ask (keep theirs, replace, or write `ci.dannflow.yml` alongside).
+4. **Prove it green BEFORE relying on it.** Run each referenced script locally:
+   ```bash
+   <pm> install
+   <pm> run build      # only the scripts that exist
+   <pm> run lint
+   <pm> run typecheck
+   ```
+   - If any fails, **stop before enabling branch protection** and report exactly which script failed. A required check that can't pass bricks the repo.
+   - If all pass, continue.
+
+---
+
+## Step 3 — Create the version anchor (`dannflow.json`)
+
+1. Ensure the `upstream` remote exists:
+   ```bash
+   git remote get-url upstream 2>/dev/null || git remote add upstream https://github.com/Danncode10/DannFlow.git
+   git fetch upstream --quiet
+   UPSTREAM_SHA=$(git rev-parse upstream/main)
+   ```
+2. Write `dannflow.json` at the repo root (note the **new fields** for the branch flow):
+   ```json
+   {
+     "dannflow_commit": "<UPSTREAM_SHA>",
+     "synced_at": "<ISO timestamp now>",
+     "repo": "https://github.com/Danncode10/DannFlow",
+     "base_branch": "main",
+     "dev_branch": "dev"
+   }
+   ```
+   Tell the user this file is the "version label" — every future sync reads and updates it.
+
+---
+
+## Step 4 — Set up the branch flow
+
+The project's own counters: `feat/* → dev → main`.
+
+1. Create `dev` off `main` if missing:
+   ```bash
+   git rev-parse --verify dev 2>/dev/null || git branch dev main
+   git push -u origin dev
+   ```
+2. **Branch protection** (skip if `--no-protect` or no `gh`): require the CI check on `main` (and optionally `dev`) so nothing reaches the serving plate un-checked. Use the GitHub MCP / `gh api`. Confirm with the user before applying — this needs admin scope.
+3. Do **not** pre-create `feat/*` branches — those are made on demand (the next step makes the first one).
+
+---
+
+## Step 5 — First sync (hand off to `/sync-upstream`)
+
+Run `/sync-upstream` behavior to pull the template in for the first time. It lands changes on a `feat/sync-...` branch and opens a PR into `dev` (see that command). This is the "first grocery run."
+
+---
+
+## Step 6 — Commit with provenance
+
+Stage only what adoption created (`.github/workflows/ci.yml`, `dannflow.json`, and any synced template files), then commit with the trailer spec below:
+
+```
+chore: adopt DannFlow conventions (CI, version anchor, branch flow)
+
+DannFlow-Action: adopt
+DannFlow-Source: Danncode10/DannFlow@<UPSTREAM_SHA>
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+---
+
+## DannFlow provenance trailer spec (canonical — referenced by the other sync commands)
+
+Every DannFlow command that moves files between a project and the template records **machine-readable provenance** as git trailers (`Key: Value` lines at the *bottom* of the commit message). The subject line still describes **what changed**; the trailers describe **where it came from**.
+
+| Trailer | Used by | Value |
+|---|---|---|
+| `DannFlow-Action:` | all | `adopt` \| `sync-upstream` \| `contribute` |
+| `DannFlow-Source:` | adopt, sync-upstream (incoming) | `Danncode10/DannFlow@<sha>` — the template commit pulled FROM |
+| `DannFlow-Origin:` | sync-to-upstream (outgoing) | `<repo>@<sha>` — the project commit the change came FROM |
+
+Rules:
+- **Never** put "ran <command>" in the subject line — the subject says what changed. A computer can find the rest with `git log --grep "DannFlow-Action: sync-upstream"`.
+- **Never** record the redundant "ran in this repo" — the commit already lives here. Record the **cross-repo link + SHA**, which is the part git history can't otherwise recover.
+- The SHA in `DannFlow-Source:` should match `dannflow.json`'s `dannflow_commit`, so the anchor is recoverable from history if the file is lost.
+
+---
+
+## Safety rules
+
+- **Refuse on a dirty tree.** Adoption touches multiple files; never mix with uncommitted work.
+- **Never enable branch protection before CI is proven green** — a required check that can't pass makes the repo un-mergeable.
+- **Never overwrite an existing `ci.yml`** without showing a diff and asking.
+- **Never** force-push or rewrite `main`. Adoption only adds branches and files.
+- If anything in Steps 1–4 fails, stop and report — do not continue to branch protection or sync on a half-set-up repo.
+
+---
+
+## See also
+
+- `/sync-upstream` — keep an adopted project current (run forever after).
+- `/sync-to-upstream` — contribute your improvements back up to DannFlow.
+- `/update-dannflow` — smart entry point that auto-detects version and updates.

--- a/.claude/commands/sync-to-upstream.md
+++ b/.claude/commands/sync-to-upstream.md
@@ -64,6 +64,7 @@ Scan these paths for files that differ between your `HEAD` and `upstream/main`:
 
 ```
 .claude/commands/        (top-level .md files only — exclude Ruflo subdirectories)
+.claude/agents/
 .claude/skills/
 CLAUDE.md
 SKILLS.md
@@ -73,6 +74,8 @@ docs/dannflow_docs/
 scripts/
 src/prompts/features/
 ```
+
+> Keep this list in sync with `/sync-upstream`'s default scan paths — the two commands should cover the same file set in both directions. **Exception:** `.github/workflows/ci.yml` is intentionally excluded here. Your project's `ci.yml` is tuned to *your* package manager and scripts; pushing it up would pollute the generic template. Contribute CI *improvements* by hand, not the tuned file.
 
 **Exclude from scanning (always business-specific — never upstream candidates):**
 
@@ -244,10 +247,19 @@ C) Skip for now — patches are saved to /tmp/dannflow-upstream-patch/ for later
 
 3. Run `git diff` in the clean clone to confirm only the right changes are staged.
 
-4. Create a commit:
+4. Create a commit with provenance trailers (see the canonical spec in `/adopt-dannflow`). Record where the contribution came FROM — the origin repo and commit — so DannFlow history shows which project each improvement originated in:
+   ```
+   feat: <contribution description>
+
+   DannFlow-Action: contribute
+   DannFlow-Origin: <origin repo slug>@<your HEAD short sha>
+
+   Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+   ```
+   Get the origin slug + sha from the *project* repo before cloning: `git remote get-url origin` and `git rev-parse --short HEAD`.
    ```bash
    git add <specific files only>
-   git commit -m "feat: <contribution description>"
+   git commit -F <message-file>
    ```
 
 5. Ask before pushing:
@@ -258,7 +270,7 @@ C) Skip for now — patches are saved to /tmp/dannflow-upstream-patch/ for later
 
 6. If confirmed: `git push origin <branch-name>`
 
-7. Print the PR URL:
+7. Open the PR directly via the GitHub MCP (`create_pull_request`) or `gh pr create --repo Danncode10/DannFlow --base main --head <branch-name>` — DannFlow has no `dev` branch, so contributions PR straight into `main`, where its CI gate keeps the template clean. If neither is available, print the compare URL as a fallback:
    ```
    https://github.com/Danncode10/DannFlow/compare/<branch-name>
    ```

--- a/.claude/commands/sync-upstream.md
+++ b/.claude/commands/sync-upstream.md
@@ -8,6 +8,8 @@ Pull selective updates from the DannFlow upstream repo without merging or rebasi
 
 > **Version-aware:** This command reads `dannflow.json` at the project root to know which DannFlow commit you last synced from, so it can show you only what's new since then.
 
+> **Branch flow (the "serving plate stays clean" rule).** Synced changes do **not** land on whatever branch you're standing on. They land on a fresh `feat/sync-upstream-<short-sha>` branch and open a **PR into `dev`** (the `dev_branch` from `dannflow.json`). That routes every synced change through the same CI gate as your own work, so `main` is never touched directly. `dev → main` stays a normal PR you open after eyeballing CI. If the repo has no `dev` branch yet, it hasn't been adopted — tell the user to run `/adopt-dannflow` first.
+
 **Two modes** — file-level is the default and recommended:
 
 | Mode | When to use |
@@ -93,6 +95,8 @@ src/prompts/features/
 
 **Never auto-touch:** `src/app/`, `src/components/`, `src/services/`, `src/lib/config.ts`, `.env*`, `package.json`, `package-lock.json`, `supabase/`, `public/`, `next.config.ts`, `tsconfig.json`. The user's app code lives here — copying upstream over it would destroy their work. If the user explicitly passes one of these as a path arg, allow it but warn loudly first.
 
+**Project-tuned — diff-only, never auto-pull:** `.github/workflows/ci.yml`. This file was rewritten by `/adopt-dannflow` to match *this* project's package manager, Node version, and scripts. Blindly copying upstream's generic version over it would break the CI gate (and once CI is a required check, that blocks every merge). If it differs from upstream, only ever **show the diff** and let the user hand-merge — never `git checkout upstream/main` over it. The rest of `.github/` (PR template, dependabot) is fine to sync normally.
+
 ### Procedure
 
 1. **Build a change report** for the scanned paths:
@@ -126,7 +130,16 @@ src/prompts/features/
    - `none` / `q` to quit
    - For each modified file, also offer `view N` to show the diff before deciding
 
-5. **Apply the user's choices**, file by file:
+5. **Create the landing branch first**, off the project's `dev` branch — so synced changes ride the CI gate instead of landing loose on `main`:
+   ```bash
+   UPSTREAM_SHA=$(git rev-parse upstream/main)
+   SHORT_SHA=$(git rev-parse --short upstream/main)
+   DEV_BRANCH=$(node -p "require('./dannflow.json').dev_branch || 'dev'")
+   git rev-parse --verify "$DEV_BRANCH" >/dev/null 2>&1 || { echo "No '$DEV_BRANCH' branch — run /adopt-dannflow first."; exit 1; }
+   git checkout -b "feat/sync-upstream-$SHORT_SHA" "$DEV_BRANCH"
+   ```
+
+6. **Apply the user's choices** onto that branch, file by file:
    - 🆕 NEW: `git checkout upstream/main -- <path>` (creates the file locally)
    - ✏️ MODIFIED:
      - First show `git diff HEAD upstream/main -- <path>` so user sees what changes
@@ -134,31 +147,43 @@ src/prompts/features/
      - If "merge manually": copy upstream version to `<path>.upstream` next to the local file so user can diff them in their editor
    - 🗑️ DELETED: just inform the user — do NOT delete their local file unless they explicitly say to
 
-6. **After applying**, run `git status` and show what changed. Do NOT auto-commit.
-
-7. **Update `dannflow.json`** with the new upstream HEAD SHA:
-   ```bash
-   UPSTREAM_SHA=$(git rev-parse upstream/main)
-   SYNCED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-   ```
-   Write the updated `dannflow.json`:
+7. **Update `dannflow.json`** with the new upstream HEAD SHA, preserving the existing branch fields:
    ```json
    {
      "dannflow_commit": "<new upstream/main SHA>",
      "synced_at": "<ISO timestamp>",
-     "repo": "<repo from existing dannflow.json>"
+     "repo": "<repo from existing dannflow.json>",
+     "base_branch": "<base_branch from existing dannflow.json, default main>",
+     "dev_branch": "<dev_branch from existing dannflow.json, default dev>"
    }
    ```
    Tell the user: "Updated dannflow.json: now tracking DannFlow at `<new sha>`"
 
-8. End with a suggested conventional commit message, e.g.:
+8. **Commit on the sync branch** with provenance trailers (see the canonical spec in `/adopt-dannflow`). Stage only the touched files plus `dannflow.json` — never `git add -A`:
    ```
    chore(sync): pull upstream updates to .claude/commands/ and SKILLS.md
+
+   DannFlow-Action: sync-upstream
+   DannFlow-Source: Danncode10/DannFlow@<UPSTREAM_SHA>
+
+   Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
    ```
+   The subject describes *what files changed*; the trailers record *which template commit it came from*. The `DannFlow-Source` SHA must match `dannflow.json`'s `dannflow_commit`.
+
+9. **Open a PR into `dev`** (use the GitHub MCP / `gh pr create`), so CI gates the synced changes. Ask before pushing. Stop here — do **not** auto-merge to `main`; that promotion is a human checkpoint after CI goes green:
+   ```bash
+   git push -u origin "feat/sync-upstream-$SHORT_SHA"
+   gh pr create --base "$DEV_BRANCH" --head "feat/sync-upstream-$SHORT_SHA" \
+     --title "chore(sync): DannFlow @$SHORT_SHA" --body "Synced from Danncode10/DannFlow@$SHORT_SHA"
+   ```
+   If `gh` is unavailable, fall back to leaving the committed branch and printing the compare URL.
 
 ### Safety rules for file-level mode
 
 - **Never** `git checkout upstream/main -- .` (whole tree). Always scoped paths.
+- **Never** land synced changes directly on `main` or `dev`. Always the `feat/sync-upstream-<sha>` branch → PR into `dev`. If there's no `dev` branch, stop and point the user to `/adopt-dannflow`.
+- **Never** auto-merge the sync PR to `main` — that promotion is a human checkpoint after CI passes.
+- **Never** `git checkout upstream/main` over `.github/workflows/ci.yml` — diff-only (it's project-tuned).
 - **Never** auto-overwrite a modified file without showing the diff first.
 - If a target file has uncommitted local changes (`git status --porcelain <path>` is non-empty), warn and require explicit confirmation before overwriting.
 - After every checkout, stage only what was touched — never use `git add -A`.

--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Run `./guide.sh commands` to see all 16 commands. Key ones:
 | [docs/dannflow_docs/methodology.md](docs/dannflow_docs/methodology.md) | Vibe Coding + Zero-Hallucination philosophy |
 | [docs/dannflow_docs/the-holy-trinity.md](docs/dannflow_docs/the-holy-trinity.md) | Types + Schema + Services model |
 | [docs/dannflow_docs/mcp-setup.md](docs/dannflow_docs/mcp-setup.md) | Supabase + GitHub MCP setup |
+| [docs/dannflow_docs/branching-and-sync.md](docs/dannflow_docs/branching-and-sync.md) | **Branch flow** (feat→dev→main), CI gate, adopt/sync/contribute model |
 | [docs/dannflow_docs/backups-and-sync.md](docs/dannflow_docs/backups-and-sync.md) | Checkpoint + sync-types loop |
 | [docs/dannflow_docs/ui-system.md](docs/dannflow_docs/ui-system.md) | Semantic tokens + UI standards |
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🚀 DannFlow (2026 Edition)
 
-**The Claude Code-Optimized SaaS Starter.** Built for AI-assisted development with Claude Code, Cursor, or Antigravity — Next.js 15+, Supabase, Tailwind v4, Shadcn UI, with auth, dashboard, RLS-first design, and 16 built-in slash commands.
+**The Claude Code-Optimized SaaS Starter.** Built for AI-assisted development with Claude Code, Cursor, or Antigravity — Next.js 15+, Supabase, Tailwind v4, Shadcn UI, with auth, dashboard, RLS-first design, and 34 built-in slash commands.
 
 > **Built for Speed. Structured for Agents. Optimized for the Vibe.**
 
@@ -78,12 +78,30 @@ git remote add origin https://github.com/YOUR_USERNAME/my-template.git
 git push -u origin main
 ```
 
+**Already have a repo that *didn't* start from DannFlow?** Adopt it in one command:
+```bash
+/adopt-dannflow   # installs CI, creates the dannflow.json anchor + dev branch, then syncs
+```
+
 **Sync updates from the parent later:**
 ```bash
 /sync-upstream   # pulls selective updates from upstream into your project
 ```
 
 `/sync-upstream` only touches safe files (commands, docs, scripts) — never your app code.
+
+### Clean by default: the `feat → dev → main` flow
+
+Adopted projects get a branch flow that keeps `main` always shippable:
+
+```
+feat/*  →  dev  →  main
+  prep      test    release
+```
+
+Every promotion runs the CI check (`.github/workflows/ci.yml`), so nothing reaches `main` un-tested. `/sync-upstream` respects this — synced changes land on a `feat/sync-*` branch and open a PR into `dev`, never straight onto `main`. DannFlow itself stays on `main`-only (no `dev`) so the template is always green.
+
+→ Full details in [docs/dannflow_docs/branching-and-sync.md](docs/dannflow_docs/branching-and-sync.md).
 
 ---
 
@@ -222,7 +240,7 @@ supabase/
 └── backups/          # Schema snapshots from npm run checkpoint
 
 .claude/
-├── commands/         # 16 DannFlow slash commands
+├── commands/         # 34 DannFlow slash commands
 ├── agents/           # Ruflo agent definitions
 ├── skills/           # Installed skill packs
 └── settings.json     # Ruflo hook wiring
@@ -232,14 +250,15 @@ supabase/
 
 ## ⚡ Slash Commands
 
-Run `./guide.sh commands` to see all 16 commands. Key ones:
+Run `./guide.sh commands` to see all 34 commands. Key ones:
 
 | Command | When to use |
 |---|---|
 | `/ask-command <intent>` | Don't know which command? This routes you. |
 | `/init-claude` | Tailor CLAUDE.md + SKILLS.md to your project |
 | `/make-command <name>` | Create a new slash command |
-| `/sync-upstream` | Pull selective updates from the parent template |
+| `/adopt-dannflow` | Bootstrap a non-DannFlow repo: CI + dannflow.json + dev branch, then sync |
+| `/sync-upstream` | Pull selective updates from the parent template (PRs into `dev`) |
 | `/checkpoint` | Snapshot DB before risky schema changes |
 | `/sync-types` | Regenerate types after schema changes |
 | `/new-feature <name>` | Scaffold service + page + form |
@@ -263,7 +282,7 @@ Run `./guide.sh commands` to see all 16 commands. Key ones:
 
 | Doc | What it covers |
 |---|---|
-| [docs/dannflow_docs/claude-workflow.md](docs/dannflow_docs/claude-workflow.md) | **START HERE** — daily loop, all 16 commands |
+| [docs/dannflow_docs/claude-workflow.md](docs/dannflow_docs/claude-workflow.md) | **START HERE** — daily loop, all 34 commands |
 | [docs/dannflow_docs/methodology.md](docs/dannflow_docs/methodology.md) | Vibe Coding + Zero-Hallucination philosophy |
 | [docs/dannflow_docs/the-holy-trinity.md](docs/dannflow_docs/the-holy-trinity.md) | Types + Schema + Services model |
 | [docs/dannflow_docs/mcp-setup.md](docs/dannflow_docs/mcp-setup.md) | Supabase + GitHub MCP setup |

--- a/docs/dannflow_docs/backups-and-sync.md
+++ b/docs/dannflow_docs/backups-and-sync.md
@@ -1,13 +1,28 @@
-# The "Time Machine" Workflow
+# The "Time Machine" Workflow — Database Backups & Type Sync
 
-When you are "Vibe Coding," you will change your database frequently. Follow this loop:
+When you are "Vibe Coding," you will change your database frequently. This loop keeps your AI's view of the schema honest and gives you a restore point if something breaks.
 
-1. **Change**: Tell the AI to modify the DB (via Supabase MCP).
-2. **Sync**: Run `npm run update-types` to update the AI's "Eyes."
-3. **Checkpoint**: Every time you finish a feature, run `npm run checkpoint`. 
-   - The script will generate a specific prompt for your AI Agent.
-   - **Copy and paste** that message to the AI (Antigravity).
-   - The AI will then read your live Supabase schema (via MCP) and populate a new file under `supabase/backups/`.
-   - Example: `supabase/backups/schema-04-02-2026-21-00.sql`.
+> **Two kinds of "sync" in DannFlow.** This doc covers **database** sync — keeping `src/types/supabase.ts` and your backups aligned with the live schema. For **template** sync — pulling command/doc updates from DannFlow upstream — see [branching-and-sync.md](branching-and-sync.md).
 
-If you ever break your DB, you can "Restore" by copying the SQL from your last Checkpoint file into the Supabase SQL Editor.
+## The loop
+
+1. **Change**: Tell Claude Code to modify the DB (via the Supabase MCP, or `/migrate <description>`).
+2. **Sync types**: Run `npm run update-types` (or `/sync-types`) to refresh `src/types/supabase.ts` — the AI's "Eyes." Never let it guess the schema.
+3. **Checkpoint**: Every time you finish a feature, run `npm run checkpoint` (or `/checkpoint`).
+   - The script verifies your Supabase MCP connection and generates a prompt.
+   - Claude Code reads your live Supabase schema (tables, enums, RLS policies, triggers, functions) via MCP.
+   - It writes a new timestamped DDL snapshot under `supabase/backups/`.
+   - Example: `supabase/backups/schema-2026-06-18-21-00.sql`.
+
+## Restoring
+
+If you ever break your DB, "restore" by copying the SQL from your most recent checkpoint file in `supabase/backups/` into the Supabase SQL Editor and running it.
+
+## The golden rule
+
+**Change → Sync types → Checkpoint.** Do the type-sync *immediately* after any schema change so the AI never works against a stale `src/types/supabase.ts`. Checkpoint before anything destructive so you always have a way back.
+
+## See also
+
+- [branching-and-sync.md](branching-and-sync.md) — pulling template updates from DannFlow upstream (a different kind of sync).
+- [the-holy-trinity.md](the-holy-trinity.md) — why Types + Schema + Services must stay aligned.

--- a/docs/dannflow_docs/branching-and-sync.md
+++ b/docs/dannflow_docs/branching-and-sync.md
@@ -1,0 +1,103 @@
+# Branching & Sync — Keeping Every Repo Clean
+
+This is how a DannFlow project stays safe to ship and stays in sync with the template, without anyone ever breaking `main`.
+
+## The kitchen model
+
+Think of **DannFlow** as a master recipe book. It's always clean. Nobody cooks *in* it — you only copy recipes *out* of it. Each of your **projects** is a separate kitchen that started by photocopying that book.
+
+There are only **two relationships** to understand, and they have different rules:
+
+1. **Inside one project** — how you cook safely: `feat/* → dev → main`.
+2. **Between a project and DannFlow** — how recipes are copied: file-by-file, because the histories are unrelated.
+
+Keep these separate in your head and everything else follows.
+
+---
+
+## 1. Inside a project: `feat → dev → main`
+
+Every adopted project has three "counters":
+
+| Branch | Role |
+|---|---|
+| `feat/...` | Prep counter — you chop and experiment here. Messy is fine. |
+| `dev` | Tasting counter — changes are combined and CI-checked here. |
+| `main` | The serving plate — only finished, CI-passed work lands here. |
+
+Work always flows **prep → tasting → plate**. The **CI safety-check (`.github/workflows/ci.yml`)** runs at each promotion, so nothing reaches `main` un-checked. Branch protection on `main` (and optionally `dev`) enforces this — you can't push straight to the plate.
+
+> ⚠️ Because CI is a **required check**, a broken `ci.yml` blocks *every* merge. That's why `/adopt-dannflow` proves the workflow passes before turning it into a required check, and why `ci.yml` is tuned per-project (your package manager, Node version, and the scripts that actually exist).
+
+**DannFlow itself needs only `main` + short-lived `feat/*`** — no `dev`. Nobody develops features into the template; its only inbound is contributions (below), which arrive as PRs into `main` and are gated by its own CI. That's what keeps the master book spotless.
+
+---
+
+## 2. Between a project and DannFlow: copying recipes
+
+Your project has **rewritten git history** (from `guide.sh init`), so it shares **no common ancestor** with DannFlow. A normal `git merge`/PR across that boundary is impossible. Instead, DannFlow commands copy **individual files** and track versions with a small label file.
+
+### The version label: `dannflow.json`
+
+```json
+{
+  "dannflow_commit": "<the DannFlow commit you last synced from>",
+  "synced_at": "<ISO timestamp>",
+  "repo": "https://github.com/Danncode10/DannFlow",
+  "base_branch": "main",
+  "dev_branch": "dev"
+}
+```
+
+This file is the anchor every sync reads and updates. If `dannflow.json` is missing, the repo was never adopted — run `/adopt-dannflow`.
+
+### The three commands
+
+| Command | Direction | What it does |
+|---|---|---|
+| **`/adopt-dannflow`** | setup (once) | Installs `ci.yml` (and proves it green), writes `dannflow.json`, creates `dev`, then runs the first sync. Turns a non-DannFlow repo into a first-class one. |
+| **`/sync-upstream`** | DannFlow → project | Copies new template files in. Lands them on `feat/sync-upstream-<sha>` and opens a PR into `dev` — so synced changes ride the same CI gate. Never touches `main` directly. |
+| **`/sync-to-upstream`** | project → DannFlow | Copies a generic improvement back up via a clean clone → `feat/*` branch → PR into DannFlow `main`. |
+
+**Decision rule:** no `dannflow.json` → `/adopt-dannflow`. Has it → `/sync-upstream` to update, `/sync-to-upstream` to contribute.
+
+---
+
+## Provenance: how we record where a change came from
+
+Every command that moves files records **machine-readable provenance** as git *trailers* (`Key: Value` lines at the bottom of the commit message). The subject line still says *what changed*; the trailers say *where it came from*.
+
+| Trailer | Used by | Value |
+|---|---|---|
+| `DannFlow-Action:` | all | `adopt` \| `sync-upstream` \| `contribute` |
+| `DannFlow-Source:` | adopt, sync-upstream | `Danncode10/DannFlow@<sha>` — template commit pulled FROM |
+| `DannFlow-Origin:` | sync-to-upstream | `<repo>@<sha>` — project commit the change came FROM |
+
+Example sync commit:
+```
+chore(sync): pull upstream updates to .claude/commands/ and SKILLS.md
+
+DannFlow-Action: sync-upstream
+DannFlow-Source: Danncode10/DannFlow@a1b2c3d
+```
+
+Why trailers instead of writing it in the subject:
+- The subject stays a real description ("added X"), not "ran a command".
+- It's searchable: `git log --grep "DannFlow-Action: sync-upstream"` finds every sync.
+- The `DannFlow-Source` SHA matches `dannflow.json`, so your version is recoverable from git history even if the label file is deleted.
+
+---
+
+## What's safe to sync (and what's never touched)
+
+`/sync-upstream` only ever copies **template files** — commands, agents, docs, scripts, blueprints. It **never** auto-touches your app code (`src/app/`, `src/services/`, `src/components/`, `config.ts`, `package.json`, `supabase/`, env files, etc.).
+
+One special case: **`.github/workflows/ci.yml` is diff-only, never auto-pulled.** It's tuned to *your* project; overwriting it with the generic template version would break your CI gate. The command shows you the diff and lets you hand-merge.
+
+---
+
+## See also
+
+- [backups-and-sync.md](backups-and-sync.md) — the database checkpoint / type-sync loop.
+- [claude-workflow.md](claude-workflow.md) — the full daily command loop.
+- `/adopt-dannflow`, `/sync-upstream`, `/sync-to-upstream`, `/update-dannflow` — the commands themselves.

--- a/docs/dannflow_docs/mcp-setup.md
+++ b/docs/dannflow_docs/mcp-setup.md
@@ -12,7 +12,7 @@ To make "DannFlow" work, the AI needs three sets of tools:
 
 ### 3. Terminal MCP (The Hands)
 - **Purpose**: Allows the AI to run commands like `npm install` or `npm run update-types` for you.
-- **Setup**: Enable "Terminal" or "Shell" access in Antigravity settings.
+- **Setup**: Enable "Terminal" or "Shell" access in your agent settings (Claude Code, Cursor, or Antigravity).
 
 ### 4. Ruflo MCP (Memory + Orchestration) — Beta
 


### PR DESCRIPTION
## Summary

Adds the `/adopt-dannflow` command and reworks the sync flow so every DannFlow project keeps a clean, CI-gated `main`. Also refreshes the docs/README to match.

### The model
- **Inside a project:** `feat/* → dev → main`, with `.github/workflows/ci.yml` gating each promotion. `main` is never touched directly.
- **Project ↔ DannFlow:** file-level copying (rewritten history = no common ancestor), tracked by `dannflow.json`.
- **DannFlow itself:** `main`-only (no `dev`), so the template stays green.

## What's in here (7 commits)

| Area | Change |
|---|---|
| New command | `/adopt-dannflow` — bootstrap a non-DannFlow repo: detect shape, install + **prove** CI, write `dannflow.json` (now with `base_branch`/`dev_branch`), create `dev`, then first sync. Defines the canonical provenance-trailer spec. |
| `/sync-upstream` | Synced changes land on `feat/sync-upstream-<sha>` → PR into `dev` (no longer edits `main` directly). Protects the project-tuned `ci.yml` (diff-only). Adds `DannFlow-Action`/`DannFlow-Source` trailers. |
| `/sync-to-upstream` | Scan paths aligned with `/sync-upstream`, `contribute` trailer + `DannFlow-Origin`, opens the upstream PR via the GitHub MCP. |
| Docs | New `docs/dannflow_docs/branching-and-sync.md`; README command count 16→34 + branch-flow section + adopt-dannflow in Template Chain; commands index refreshed; `backups-and-sync.md` + `mcp-setup.md` de-staled (Antigravity→Claude Code). |

## Provenance trailers
Commits record where a change came from as git trailers (searchable via `git log --grep`), keeping the subject line about *what changed*:
- `DannFlow-Action: adopt | sync-upstream | contribute`
- `DannFlow-Source: Danncode10/DannFlow@<sha>` (incoming)
- `DannFlow-Origin: <repo>@<sha>` (contributions)

## Review notes
- `adopt-dannflow.md` is a **spec** — the "prove CI green before enabling branch protection" step needs a live dry-run on a real repo before trusting it widely.
- `methodology.md` intentionally left untouched (the "students" framing is deliberate positioning, no real staleness).
- `PROJECT_CONTEXT.md` is still the empty template default — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
