### PR TITLE
docs: one-paste fast path for updating old DannFlow projects

### DIFF
--- a/docs/dannflow_docs/updating-old-projects.md
+++ b/docs/dannflow_docs/updating-old-projects.md
@@ -8,6 +8,47 @@ Got a project that was built on an **older version of DannFlow** — one that do
 
 ---
 
+## ⚡ Fast path — the one-paste update (recommended)
+
+Don't want to type any of the steps below? Do this instead.
+
+**1. Open the old project in Claude Code on Opus:**
+```bash
+cd ~/path/to/your-old-project
+claude --model opus
+```
+> `--model opus` sets the session to Claude Opus automatically. (Already in a session? Just run `/model opus` once.)
+
+**2. Paste this whole block into Claude and send it:**
+
+```text
+Update THIS project to the latest DannFlow, autonomously. Pause only if something is genuinely unsafe or ambiguous.
+
+Hard rules:
+- NEVER run `git merge`. If branches need combining, stop and ask me first.
+- Never touch the `origin` remote.
+- Never modify my app code or project identity: src/, package.json, package-lock.json, supabase/, public/, .env*, CLAUDE.md, AGENTS.md, SKILLS.md, README.md, PROJECT_CONTEXT.md, docs/. Template files only.
+
+Steps:
+1. Preflight. If the working tree is dirty ONLY because of tool artifacts (.claude-flow/, .swarm/, ruvector.db), add them to .gitignore and commit. If it's dirty with real work, STOP and tell me to commit/stash first.
+2. If there is no `upstream` git remote, add it: git remote add upstream https://github.com/Danncode10/DannFlow.git
+3. Run: git fetch upstream
+4. Bootstrap the latest commands ONLY (this is a file copy, NOT a merge): git checkout upstream/main -- .claude/commands/ — then commit it as "chore: bootstrap latest DannFlow commands from upstream". This copy never deletes my custom commands; it only adds/overwrites DannFlow's.
+5. Read the file .claude/commands/adopt-dannflow.md and execute its steps exactly, as if I had run `/adopt-dannflow --force`. You do NOT need the slash command registered — just follow the file. This installs CI, writes dannflow.json, creates the dev branch, and runs the first sync.
+6. When you create any PR with `gh`, ALWAYS pass `--repo <my origin owner/repo>` explicitly. My repo has two remotes (origin + upstream), which otherwise confuses gh and makes PR creation fail with a misleading "No commits between" / "Head sha can't be blank" error.
+7. Land changes on a feature branch and open a PR into `dev` (never commit straight to main).
+
+Note: if branch protection on main returns HTTP 403 ("Upgrade to GitHub Pro or make this repository public"), that's a GitHub plan limit, not an error — just report it and continue. Everything else should still complete.
+
+First show me a 3-line plan. Then proceed.
+```
+
+That's it. Claude reads the freshly-copied `adopt-dannflow.md` and runs it in the same session — **no restart needed**, because Claude follows the file directly instead of waiting for the slash command to register.
+
+> The manual steps below are the same thing, broken out — useful if the paste hits a snag and you want to drive it yourself.
+
+---
+
 ## The chicken-and-egg problem
 
 A slash command can't install itself. If your old project doesn't have the new `/adopt-dannflow` or an up-to-date `/sync-upstream`, you can't just "run the new command" — it isn't there yet. So the **first step is always to get the latest command files in by hand**, then run them normally.


### PR DESCRIPTION
Adds a single copy-paste prompt to `updating-old-projects.md` so any old DannFlow project can be updated by pasting one block into Claude (launched on Opus via `claude --model opus`).

The prompt bootstraps the latest commands, then has Claude **read and follow** `adopt-dannflow.md` as `--force` — no Claude restart needed, since it follows the file directly instead of waiting for the slash command to register.

Bakes in the gotchas from the first live adoption run on attyjuan-sched:
- **Never `git merge`** (the add/add conflict trap)
- gitignore tool artifacts (`.claude-flow/`, `.swarm/`, `ruvector.db`) to clear a dirty tree
- pass `gh --repo <origin>` explicitly (two remotes confuse gh → misleading 'No commits between' error)
- treat branch-protection 403 as a non-fatal GitHub plan limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)