### PR TITLE
feat: /new-project + /design-project — two-phase project setup commands

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -6,6 +6,8 @@ Drop `.md` files in this folder to add custom slash commands. Each file becomes 
 
 | Command | Purpose |
 |---|---|
+| `/new-project ["name"]` | **Start a new project (Phase 1).** Interviews you for the project facts, writes `business.json` + `README` + `PROJECT_CONTEXT`, rebrands the code, creates a GitHub repo and repoints `origin` (keeps DannFlow as `upstream`), wires the Claude env (`/business-init` → `/init-claude` → `/ruflo-upgrade`), and stands up the Supabase tenant. |
+| `/design-project ["section"]` | **Then design it (Phase 2). ⭐ Use Opus.** Claude reads README + `business.json` + `PROJECT_CONTEXT`, runs a design-taste interview, then strictly replaces the template's placeholder copy, theme, and sections with a bespoke design for this project. |
 | `/init-claude` | Reads `README.md` + scans `src/` + `package.json`, then auto-rewrites `CLAUDE.md`, `SKILLS.md`, and refreshes this README to match the actual project state. |
 | `/ask-command` | Meta-router. Describe what you want in plain English; it searches all commands here and returns the best one + a ready-to-paste prompt. |
 | `/security-audit` | Full security scan: secrets in client bundles, service-role key leaks, `dangerouslySetInnerHTML`, missing `'use server'`, XSS vectors. |

--- a/.claude/commands/design-project.md
+++ b/.claude/commands/design-project.md
@@ -1,0 +1,146 @@
+---
+description: "PHASE 2 of 2 — Claude designs and builds the actual site. Reads README + business.json + PROJECT_CONTEXT, runs a design-taste interview, then strictly replaces the template's placeholder copy, theme, and sections with a bespoke design for THIS project. Run after /new-project. ⭐ Use Opus — this is the creative, judgement-heavy phase."
+argument-hint: "[section name to focus on] (optional — defaults to the whole site)"
+---
+
+# /design-project  ·  Phase 2: Design & Build
+
+> ⭐ **Use Opus for this command.** This phase is pure design judgement — taste, hierarchy, copy, restraint. Run it on the most capable model. If you're on a smaller model, say so and recommend switching before continuing.
+
+> **Prerequisite:** `/new-project` (Phase 1) has run — the repo is rebranded, `business.json` is filled, the Claude env is wired, and the Supabase tenant exists. If `business.json` still has template defaults (name "DannFlow", appId "dannflow"), stop and tell the user to run `/new-project` first.
+
+Your job: turn the template's generic placeholder site into a **bespoke, production-quality site for this specific project** — designed entirely by you. Don't ask the user to write copy or pick layouts they can't picture. Interview for taste and facts, then *design all of it* and show them the result.
+
+## What it does
+
+1. **Load the brief** — README + business.json + PROJECT_CONTEXT + the landing design system.
+2. **Design interview** — a short, focused conversation about taste, references, and content you can't infer.
+3. **Design the system** — set the theme (colors, type, mood) to fit the project; lock the section list.
+4. **Build every section** — rewrite each landing component with real copy, structure, and content. No Lorem ipsum, no "Your Business Name" leftovers.
+5. **Wire the data** — connect feature sections (services, pricing, gallery, testimonials, contact) to `business.json` / the Supabase tables created in Phase 1.
+6. **Verify** — typecheck, `/no-conflict`, and a responsive pass. Report what was designed.
+
+---
+
+## Step 0 — Confirm the model + load the brief
+
+1. If not running on Opus, recommend switching ("This is the design phase — Opus gives noticeably better taste. Switch and re-run, or continue on this model?"). Respect the user's choice.
+2. Read in parallel — this is your design brief, treat it as source of truth:
+   - `README.md` — what this project is and offers
+   - `business.json` — name, vertical, services/features, contact, hours, social proof, branding hints
+   - `PROJECT_CONTEXT.md` — audience, tone, design rules, **anti-decisions** (respect these absolutely)
+   - `CLAUDE.md` — guardrails (semantic tokens, server-first, services layer, RLS)
+   - `src/app/globals.css` — current `@theme` tokens you'll be retuning
+   - `src/components/landing/*` and `src/components/navbar.tsx` — the components you'll redesign
+3. **Recall the landing design system** from memory (search: "landing-design-system" / "landing design"). It defines the dark-premium vocabulary, the Framer Motion **perf rules**, and a FORBIDDEN animation list. Reuse those patterns; do not reintroduce the Safari-breaking blur-in animations.
+
+---
+
+## Step 1 — Design-taste interview (short, sharp)
+
+Ask only what you genuinely can't infer from the brief. Group it so the user answers fast. Cover:
+
+- **Vibe / references**: 2–3 sites or brands they admire, or 3 adjectives (e.g. "warm, trustworthy, local" vs "sleek, premium, minimal"). If they have none, propose a direction from the vertical and confirm.
+- **Mood + palette**: light or dark? Keep the template's purple-on-OLED, or move to colors that fit the brand? Offer a concrete recommendation.
+- **Hero promise**: the single most important sentence — what they want a first-time visitor to feel/do. You'll write the actual headline; just get the intent.
+- **Content you can't invent**: real service/feature names + prices, signature offerings, a genuine testimonial or two, real photos (or confirm you should use tasteful placeholders/stock direction).
+- **Sections**: confirm the page outline (see Step 3) — add/remove based on `features` and what the project offers.
+- **Must-haves / must-avoids**: anything non-negotiable, plus things to never do (feeds PROJECT_CONTEXT anti-decisions).
+
+Keep it to one or two rounds. Then **show the user the design plan** (palette + section list + hero direction) and get a "go" before building.
+
+---
+
+## Step 2 — Set the design system (theme first)
+
+Before touching sections, lock the foundation in `src/app/globals.css` `@theme`:
+
+- Retune `--color-*` tokens to the chosen palette. Keep the **semantic token contract** intact (background / foreground / card / muted / primary / accent / border / destructive) so every component re-themes automatically. **Never** hardcode hex/`rgba`/`white`/`black`/`gray-*` in `className` — that's a CLAUDE.md critical failure. All color lives in tokens.
+- Pick type + spacing mood consistent with the vibe (the system uses Geist; change only if the brand demands it).
+- Sync `branding.primaryColor` / `accentColor` in `business.json` to the final tokens.
+
+State the before/after palette so the change is reviewable.
+
+---
+
+## Step 3 — Lock the section list
+
+Default landing outline (prune/extend from `business.json.features` + the interview):
+
+| Section | Component | Driven by |
+|---|---|---|
+| Hero | `hero.tsx` | headline + promise (you write it) |
+| Social proof bar | `social-proof-bar.tsx` | `socialProof.*` |
+| Services / What we offer | `services.tsx` | real services/features (+ `services` table if present) |
+| How it works | `how-it-works.tsx` | the offering's flow |
+| Pricing / Packages | `pricing.tsx` / `packages.tsx` | `features.pricing` |
+| Gallery | `gallery.tsx` | `features.gallery` |
+| Testimonials | `testimonials.tsx` | `features.testimonials` (+ `reviews` table) |
+| Blog preview | `blog-preview.tsx` | `features.blog` |
+| Contact + hours + map | `contact-block.tsx` | `contact.*`, `hours.*` |
+| CTA banner | `cta-banner.tsx` | the primary action |
+
+Delete sections a feature flag turned off; don't leave dead placeholder blocks. (Some components may not exist yet in a given DannFlow project — scaffold them with `/new-page` or `/new-feature` patterns if needed.)
+
+---
+
+## Step 4 — Build every section (design all)
+
+For each section in the locked list, **rewrite the component** to be specific to this project:
+
+- **Real copy** — headlines, subheads, body, CTAs written for *this* project. Zero placeholder text, zero "Your Business Name", zero Lorem ipsum left anywhere.
+- **Reuse the design vocabulary** from the landing design system: eyebrow → gradient-word H2 → subtitle; double-bezel cards; magnetic CTA; one ambient orb per section; alternating cascade for feature rows.
+- **Respect the perf + motion rules** — initial `{ opacity:0, y:16 }` (never blur-in), 0.5–0.7s, `whileInView { once:true, margin:'-60px' }`, stagger `i*0.04`. Honor the FORBIDDEN list from memory.
+- **Guardrails** — Server Components by default (`'use client'` only for interaction); semantic tokens only; any data fetch goes through `src/services/` with the `app_id` + `organization_id` filters; ≥48px touch targets; labels above inputs; Shadcn `<Button>`/`<Card>`.
+- **Mobile-first** — design at 375px up; no horizontal scroll; real empty states.
+
+Also refresh shared chrome that carries the brand: `navbar.tsx`, footer, page metadata in `src/app/layout.tsx` and `page.tsx` (title/description/OG from `business.json` + `seo.*`).
+
+---
+
+## Step 5 — Wire the data
+
+For enabled features, connect the section to real data instead of hardcoding where a table exists:
+- `services` / `pricing` → `services` table (or `business.json` if no table)
+- `gallery` → `gallery_items`
+- `testimonials` → `reviews`
+- `contactForm` → inserts into `leads`
+All via `src/services/` with tenant filters (`app_id` + `organization_id`). Never query Supabase directly from a component. If a table is missing for an enabled feature, fall back to `business.json`-driven static content and note it.
+
+---
+
+## Step 6 — Verify & report
+
+1. `npx tsc --noEmit` — fix any errors.
+2. Run **`/no-conflict`** — confirm docs/code agree, no leftover template references, RLS intact.
+3. Responsive pass (or run **`/ui`** on the changed files) — 375px+, focus rings, touch targets, semantic tokens only.
+4. Suggest `npm run dev` so the user can see it.
+
+Report:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  🎨 <Project Name> — designed
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Palette:   <before> → <after>
+  Sections:  <built list>   Removed: <pruned list>
+  Data-wired: <services/gallery/testimonials/contact>
+  Checks:    ✅ tsc   ✅ /no-conflict   ✅ responsive
+
+  Preview:   npm run dev
+  Ship:      deploy to Vercel (separate app, same shared Supabase)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+End with a one-line conventional commit suggestion (e.g. `feat: design <project> landing site`).
+
+---
+
+## Hard rules
+
+- **Design everything — leave nothing generic.** No placeholder copy, no template defaults, no empty stub sections. If you lack a real fact, ask in the interview or make a tasteful, clearly-labeled assumption — never ship "Your Business Name".
+- **Semantic tokens only** — hardcoded hex/`rgba`/`white`/`black`/`gray-*` in `className` is a critical failure. Retheme via `globals.css` tokens.
+- **Honor the perf/motion rules** from the landing design system — never reintroduce blur-in hydration animations or animated orbs.
+- **Respect PROJECT_CONTEXT anti-decisions** absolutely.
+- **Guardrails hold** — Server-first, all data through `src/services/` with `app_id` + `organization_id`, RLS never bypassed.
+- **Opus recommended** — flag it if running on anything smaller.
+- **Don't re-scaffold infra** — repo, env, tenant, and wiring are `/new-project`'s job. This command is design + content only.
+- **Never `git commit` automatically** — leave it to the user or `/commit`.

--- a/.claude/commands/new-project.md
+++ b/.claude/commands/new-project.md
@@ -1,0 +1,179 @@
+---
+description: "PHASE 1 of 2 — scaffold a new project from a fresh DannFlow clone. Interviews you about the project/business, writes business.json + README + PROJECT_CONTEXT, rebrands the code, creates a GitHub repo and repoints origin (keeping DannFlow as upstream), wires the Claude env, and stands up the Supabase tenant. When it finishes, run /design-project to have Claude design the actual site."
+argument-hint: "[project name]" (optional — you'll be asked if omitted)
+---
+
+# /new-project  ·  Phase 1: Scaffold
+
+> **Two-command flow:** `/new-project` (this) gets the project *standing* — repo, config, wiring, database tenant. Then **`/design-project`** has Claude *design and build* the actual site. Run them in that order.
+
+Turn a fresh DannFlow clone into a wired, repo-backed, database-connected project in one conversation. This is the boring-but-critical setup so the fun part (`/design-project`) has everything it needs. Works for any DannFlow project — SaaS, a business site, an internal tool.
+
+> Run **once**, on a freshly cloned/installed DannFlow project. If the repo is already rebranded (package.json name is no longer the template default, `business.json` filled with real data), stop and say it looks already-initialized — point the user at `/business-init` for re-syncs. (If you installed via `install.sh`, the rebrand may already be done — this command will detect that and skip it.)
+
+## What it does
+
+1. **Preflight** — clean tree, looks like an un-rebranded DannFlow project, `gh` authenticated, `dannflow.json` present.
+2. **Interview** — collect the project facts (name, what it is, contact, branding, features).
+3. **Write config** — `business.json`, `README.md`, `PROJECT_CONTEXT.md`.
+4. **Rebrand code** — `package.json`, `src/lib/config.ts`, `.env.local`. (No folder rename — that would break this session. Skipped if already rebranded.)
+5. **Git + repo** — commit on top of history, create a GitHub repo, repoint `origin`, keep `upstream` → DannFlow, push.
+6. **Wire Claude** — `/business-init` → `/init-claude` → `/ruflo-upgrade`.
+7. **Database** — pause for Supabase keys, then `/create-organization` (org row + feature tables).
+8. **Hand off** — print the repo link and tell the user to run **`/design-project`** next.
+
+---
+
+## Step 0 — Preflight (run first, in parallel)
+
+```bash
+git rev-parse --is-inside-work-tree 2>/dev/null || echo "NOT_A_REPO"
+git status --porcelain
+git remote -v
+node -p "require('./package.json').name" 2>/dev/null
+node -p "require('./business.json').deployment.appId" 2>/dev/null
+test -f dannflow.json && echo "DANNFLOW_OK" || echo "NO_DANNFLOW"
+gh auth status 2>&1 | head -1
+```
+
+Stop / branch conditions:
+- **Not a repo / no `dannflow.json`** → tell the user to clone or install DannFlow properly (the project carries `dannflow.json`).
+- **Dirty tree** → commit or stash first; this command makes many edits.
+- **Already rebranded** (package.json name is a real project name AND `business.json` has non-default data) → looks initialized; suggest `/business-init`. If only the *name* was rebranded by the installer but `business.json` is still template defaults, continue — just skip the Step 3 rename work.
+- **`origin` still points at the DannFlow template repo** → expected for a fresh clone; you'll repoint it in Step 5. (If it already points at a project repo, confirm with the user before continuing.)
+- **`gh` not authenticated** → tell them to `gh auth login`, or offer the manual-repo fallback in Step 5.
+
+---
+
+## Step 1 — Interview: the project facts
+
+Short, friendly conversation. Ask for an open-ended description first, then fill gaps. Don't dump a form — infer, then confirm. (Design taste comes later in `/design-project` — here you only need the facts.)
+
+Collect → `business.json`:
+- **Identity**: name, tagline, one-paragraph description, industry, `vertical` (`general` | `restaurant` | `service` | `retail` | `real-estate` | `education` — use `general` for SaaS / tools)
+- **Contact**: email, phone, address, website (if any), Google Maps embed URL (optional)
+- **Hours**: per-day; offer Mon–Fri 9–5 / weekend closed as a default to accept wholesale (skip for pure SaaS)
+- **Branding**: primary + accent hex (keep template defaults if they don't care — real theming happens in `/design-project`)
+- **Socials**: twitter / instagram / linkedin / facebook / youtube (null = hidden)
+- **Social proof**: rating, source, customers, years (optional)
+- **SEO**: a few keywords, og image (optional)
+- **Features**: which of `blog`, `gallery`, `testimonials`, `pricing`, `contactForm`, `teamPage`, `analytics` — these drive which tables `/create-organization` builds
+- **Client** (optional): if this is for an external client, their name/email/github
+
+Derive + confirm:
+- `SLUG` = kebab-case of the name (e.g. "Bismi Cafe & Resto" → `bismi-cafe-and-resto`)
+- `APP_ID` = `SLUG` → becomes `deployment.appId` and `NEXT_PUBLIC_APP_ID` (the RLS namespace). **Never leave it the template default (`dannflow`).**
+
+Show the derived slug + a field summary, get a "yes" before writing.
+
+---
+
+## Step 2 — Write config files
+
+- **`business.json`** — rewrite with the answers; preserve every `_note` / `_readme` key. Set `deployment.appId = APP_ID`, leave `supabase.*` null (filled in Step 7).
+- **`README.md`** — rewrite intro / feature table / description to describe **this project**. Keep the "Built on DannFlow" / template-chain and deployment sections. (`/business-init` and `/design-project` read this.)
+- **`PROJECT_CONTEXT.md`** — audience, tone, and explicit anti-decisions from the interview.
+
+Show a concise diff summary, confirm.
+
+---
+
+## Step 3 — Rebrand the code (files only — never rename the folder)
+
+> `guide.sh init` does these same edits but `mv`s the project folder last, which would break this session. We skip the rename (offered as an optional manual step at the end). If `install.sh` already rebranded the name, only fill the gaps below.
+
+1. **`package.json`** — `"name"` → `SLUG` (if still the template default).
+2. **`src/lib/config.ts`** — update the `name:` fallback to the project name. Touch only `siteConfig`, never `creatorRepos`.
+3. **`.env.local`** — `cp .env.example .env.local` if missing, then set `NEXT_PUBLIC_SITE_NAME` and `NEXT_PUBLIC_APP_ID=<APP_ID>`. **Never write secret keys.**
+
+---
+
+## Step 4 — Commit the rebrand
+
+Stage only touched files (never `git add -A`). Keep history — do **not** `rm -rf .git` (`/sync-upstream` needs the DannFlow ancestry):
+
+```bash
+git add business.json README.md PROJECT_CONTEXT.md package.json src/lib/config.ts .env.local 2>/dev/null
+git commit -m "chore: initialize <project name> from DannFlow
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Step 5 — Create the project repo and repoint origin
+
+The step that's easy to forget — why a clone's `origin` keeps pointing at the DannFlow template.
+
+1. Confirm: "I'll create a GitHub repo `<SLUG>` and point this project at it. Public or private?" (default private)
+2. Create + repoint:
+   ```bash
+   gh repo create <SLUG> --private --disable-wiki     # capture the printed URL
+   git remote set-url origin <new repo URL>           # NOT 'git remote add' — origin already exists
+   git remote -v                                      # origin = project repo, upstream = DannFlow
+   ```
+3. Push: `git push -u origin main`
+4. Re-run `git remote -v` and show the user — `origin` must NOT be the DannFlow template repo.
+
+**Manual fallback (no `gh`):** pause, have them create an empty repo (no README/license) on github.com, paste the URL, then `git remote set-url origin <url>` + verify + push.
+
+---
+
+## Step 6 — Wire the Claude environment
+
+Run in order; pass "go" where they ask, since the user already approved the flow:
+1. **`/business-init`** — syncs `business.json` → config/env, runs `tsc`, prints the setup report.
+2. **`/init-claude`** — rewrites `CLAUDE.md` / `SKILLS.md` / command docs to match this project.
+3. **`/ruflo-upgrade`** — restores memory + parallel-agent patterns `/init-claude` may have reset.
+
+---
+
+## Step 7 — Stand up the Supabase tenant
+
+1. Pause and ask the user to add to `.env.local` (never print these back):
+   ```
+   NEXT_PUBLIC_SUPABASE_URL=...
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+   SUPABASE_SERVICE_ROLE_KEY=...
+   ```
+2. Wait for confirmation they've pasted the keys.
+3. Run **`/create-organization`** — inserts the `organizations` row for this `APP_ID` and creates the feature tables.
+
+If they don't have keys yet, skip — note it as a remaining task and continue.
+
+---
+
+## Step 8 — Hand off to Phase 2
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ✅ <Project Name> is scaffolded
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Repo:    <new repo URL>
+  Slug:    <SLUG>     App ID: <APP_ID>     Vertical: <vertical>
+
+  ✅ Config written   ✅ Rebranded   ✅ Repo + origin repointed
+  ✅ Claude wired     ✅ / ⏭ Supabase tenant
+
+  👉 NEXT: run  /design-project   — Claude designs & builds the actual site.
+     (Use Opus for this — it's the creative, judgement-heavy phase.)
+
+  Later: deploy to Vercel (separate app, same shared Supabase).
+  Optional: rename the folder to match the repo —
+     cd .. && mv "<current folder>" <SLUG> && cd <SLUG>
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+---
+
+## Hard rules
+
+- **Never `rm -rf .git`** — keep the DannFlow ancestry for `/sync-upstream`.
+- **Never rename the folder mid-session** — offer it as a final manual step only.
+- **Never print or write secret values** — the user pastes Supabase keys themselves.
+- **`origin` → project repo, `upstream` → DannFlow.** Always `git remote -v` to prove it before pushing.
+- **Never `git remote add origin`** (it already exists from the clone) and **never `git add -A`**.
+- **`APP_ID` / `NEXT_PUBLIC_APP_ID` = the slug, never the template default** — it's the RLS namespace.
+- **Stop on a dirty tree or an already-rebranded repo.**
+- **Delegate, don't duplicate** — call `/business-init`, `/init-claude`, `/ruflo-upgrade`, `/create-organization`. Don't reimplement them.
+- **Don't design here** — visual design, copy, and content are `/design-project`'s job. Keep this phase to facts + wiring.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Then start building:
 npm run dev
 ```
 
+**Want Claude to design the whole site for you?** After the 5 steps, run **`/design-project`** (⭐ on Opus) — it reads your `README` + `business.json` + `PROJECT_CONTEXT`, runs a quick design-taste interview, then designs and builds every section with real copy and a fitting theme, replacing all template placeholders. Spinning up a fresh client/business project from scratch instead? **`/new-project`** does the full Phase-1 scaffold (config + GitHub repo + `origin` repoint + Supabase tenant) before you hand off to `/design-project`.
+
 ---
 
 ## 🔗 Template Chain (Build Your Own Templates)


### PR DESCRIPTION
## Summary
Adds a guided **two-command flow** for standing up a new DannFlow project, contributed up from the `business-template` downstream and generalized to fit DannFlow as the root template (SaaS, business, or tool).

| Command | Phase | What it does |
|---|---|---|
| `/new-project ["name"]` | 1 — Scaffold | Interviews for project facts, writes `business.json` + `README` + `PROJECT_CONTEXT`, rebrands the code, **creates a GitHub repo + repoints `origin`** (keeps `upstream` → DannFlow), wires the Claude env (`/business-init` → `/init-claude` → `/ruflo-upgrade`), stands up the Supabase tenant. |
| `/design-project ["section"]` | 2 — Design ⭐ Opus | Reads the brief, runs a design-taste interview, then **designs and builds every landing section** with real copy + a fitting theme, replacing all template placeholders. Honors the landing design system's perf/motion rules and the semantic-token guardrail. |

## Why
- A fresh clone's `origin` keeps pointing at the template repo, and nothing in the old setup flow repointed it — `/new-project` fixes this explicitly (`git remote set-url origin <project repo>`).
- Splitting *scaffold* (deterministic) from *design* (creative, Opus-best) keeps each command focused.
- Both commands **delegate** to existing commands (`/business-init`, `/init-claude`, `/ruflo-upgrade`, `/create-organization`, `/no-conflict`) rather than duplicating them, so they stay correct as those evolve.

## Changes
- `.claude/commands/new-project.md` — new (Phase 1)
- `.claude/commands/design-project.md` — new (Phase 2)
- `.claude/commands/README.md` — two "start here" rows
- `README.md` — pointer to `/design-project` + `/new-project` in the "After Install" section

## Generalization notes
Rewritten from the business-template originals to remove client-platform-specific assumptions: references the DannFlow template defaults instead of `business-template`, detects the `install.sh` rebrand and skips redundant work, and treats `vertical: general` (SaaS/tools) as a first-class case. Preflight checks phrase against "the template default" rather than a hardcoded slug.

## Boundaries
- Never `rm -rf .git`, never rename the project folder mid-session, never writes secrets.
- `origin` → project repo, `upstream` → DannFlow (verified before push).

Provenance: `DannFlow-Origin: Danncode10/business-template@87b2257`

🤖 Generated with [Claude Code](https://claude.com/claude-code)