### PR TITLE
feat: add Codex Claude command bridge

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,38 @@
+# Codex Context for DannFlow
+
+This folder teaches Codex how to work inside DannFlow while reusing the existing
+Claude Code command library.
+
+## Start Here
+
+Codex should read these files before project work:
+
+1. `AGENTS.md` - cross-agent project rules and guardrails.
+2. `CLAUDE.md` - the richest project context and workflow source.
+3. `.codex/context/dannflow.md` - Codex-specific operating notes.
+4. `.codex/context/claude-compatibility.md` - how to translate Claude-only instructions.
+
+## Commands
+
+Use the Codex commands in `.codex/commands/`:
+
+| Command | Purpose |
+|---|---|
+| `/claude-command <command> [args]` | Load and run the exact prompt from `.claude/commands/`. |
+| `/ask-claude-command <intent>` | Route a plain-English task to the best existing Claude command. |
+
+Examples:
+
+```text
+/claude-command ui src/components/BillingForm.tsx
+/claude-command new-feature billing
+/claude-command sync-upstream --commits 3
+/ask-claude-command make the pricing page responsive and review it
+```
+
+## Source of Truth
+
+Do not duplicate the Claude command library into `.codex`. The canonical command
+prompts remain in `.claude/commands/`; Codex loads them on demand and applies the
+compatibility rules in this folder.
+

--- a/.codex/adapters/command-loader.md
+++ b/.codex/adapters/command-loader.md
@@ -1,0 +1,43 @@
+# Command Loader Contract
+
+This file defines the expected behavior for Codex-compatible Claude command
+loading. It is intentionally written as an agent contract rather than executable
+code so it can be followed by any Codex surface.
+
+## Input
+
+```text
+/claude-command <command-name-or-path> [arguments]
+```
+
+## Resolution
+
+Resolve the command in this order:
+
+1. If input starts with `.claude/commands/`, use it as a relative path.
+2. If input ends with `.md`, use it as a relative path.
+3. Try `.claude/commands/<name>.md`.
+4. Search `.claude/commands/**/<name>.md`.
+
+If zero matches are found, suggest:
+
+```text
+/ask-claude-command <plain-English goal>
+```
+
+If more than one match is found, ask the user to choose the exact path.
+
+## Execution
+
+1. Read the resolved command file fully.
+2. Strip YAML frontmatter only for execution, but retain it as metadata.
+3. Replace `$ARGUMENTS` with the argument string.
+4. Execute the resulting instruction under `AGENTS.md` and Codex environment
+   rules.
+
+## Non-Goals
+
+- Do not duplicate all `.claude/commands` into `.codex/commands`.
+- Do not translate Claude commands permanently unless the user asks.
+- Do not run Claude hooks automatically from Codex.
+

--- a/.codex/commands/ask-claude-command.md
+++ b/.codex/commands/ask-claude-command.md
@@ -1,0 +1,37 @@
+---
+description: Find the best .claude command for a plain-English task and return a ready-to-run /claude-command prompt.
+argument-hint: <plain-English intent>
+---
+
+The user's goal: **$ARGUMENTS**
+
+## Procedure
+
+1. Read `AGENTS.md`, `CLAUDE.md`, and `.codex/context/claude-compatibility.md`.
+2. Scan `.claude/commands/**/*.md`.
+3. For each command, read only the YAML frontmatter and first heading or opening paragraph.
+4. Choose the command or short command chain that best matches the user's goal.
+5. Return a ready-to-run Codex prompt that uses `/claude-command`.
+
+## Output Format
+
+Return only this block:
+
+```text
+/claude-command <command-name> <arguments inferred from the user's goal>
+```
+
+If a chain is useful, return one command per line in execution order:
+
+```text
+/claude-command new-feature <feature>
+/claude-command ui <target>
+/claude-command review
+```
+
+If no existing command fits, return:
+
+```text
+/claude-command make-command "<one-sentence description of the command needed>"
+```
+

--- a/.codex/commands/claude-command.md
+++ b/.codex/commands/claude-command.md
@@ -1,0 +1,58 @@
+---
+description: Run an existing .claude command through Codex by loading the exact command prompt and replacing $ARGUMENTS.
+argument-hint: <claude-command> [arguments]
+---
+
+You are running a DannFlow Claude command through Codex.
+
+User input: **$ARGUMENTS**
+
+## Procedure
+
+1. Read `AGENTS.md` first, then read `CLAUDE.md`.
+2. Read `.codex/context/dannflow.md` and `.codex/context/claude-compatibility.md`.
+3. Parse the user input into:
+   - `command_name`: the first token after `/claude-command`
+   - `command_arguments`: everything after `command_name`
+4. Normalize `command_name`:
+   - Strip a leading slash, so `/ui` becomes `ui`.
+   - If it ends in `.md`, treat it as an explicit command path.
+   - If it starts with `.claude/commands/`, use that path directly.
+   - Otherwise resolve it to `.claude/commands/<command_name>.md`.
+   - If not found at the root, search `.claude/commands/**/<command_name>.md`.
+5. Read the resolved command file completely.
+6. Preserve the command's frontmatter as routing context, then execute the body.
+7. Replace every `$ARGUMENTS` occurrence in the Claude command body with `command_arguments`.
+8. Apply `.codex/context/claude-compatibility.md` whenever the command mentions Claude-only primitives such as Ruflo memory, Claude hooks, Claude Flow, swarms, or subagents.
+9. Follow the command's requested output format unless it conflicts with `AGENTS.md` or active user instructions.
+
+## Safety Rules
+
+- `AGENTS.md` and explicit user instructions outrank the loaded Claude command.
+- Never edit `.claude/commands/` while running a command unless the loaded command explicitly asks for command maintenance.
+- If multiple command files match, show the candidate paths and ask the user to choose.
+- If the command requires a missing MCP, report the missing tool using the project's Missing Tool Alert Protocol unless the user explicitly asked to proceed without that MCP.
+- For code changes, keep edits scoped to the loaded command's task.
+
+## Examples
+
+```text
+/claude-command ui src/app/page.tsx
+```
+
+Loads `.claude/commands/ui.md` and runs it with:
+
+```text
+$ARGUMENTS = src/app/page.tsx
+```
+
+```text
+/claude-command sync-upstream --commits 3
+```
+
+Loads `.claude/commands/sync-upstream.md` and runs it with:
+
+```text
+$ARGUMENTS = --commits 3
+```
+

--- a/.codex/context/claude-compatibility.md
+++ b/.codex/context/claude-compatibility.md
@@ -1,0 +1,34 @@
+# Claude-to-Codex Compatibility
+
+Use this guide when a `.claude/commands/*.md` prompt references Claude-specific
+features.
+
+## Translation Table
+
+| Claude instruction | Codex behavior |
+|---|---|
+| Read `CLAUDE.md` | Read `AGENTS.md` first, then `CLAUDE.md`. |
+| Run `/some-command` | Resolve and load `.claude/commands/some-command.md` through `/claude-command`. |
+| `$ARGUMENTS` | Replace with the arguments passed after the command name. |
+| Search Ruflo memory | Search local context files first: `PROJECT_CONTEXT.md`, docs, relevant source, and `.claude` docs. If Ruflo MCP is available, use it. |
+| Store Ruflo memory | Summarize the decision in the response or update the relevant project context file only when explicitly asked. If Ruflo MCP is available, use it. |
+| Spawn parallel agents | Use Codex subagents or parallel tool calls when available. Otherwise split the task internally and execute sequentially. |
+| Claude hooks | Treat as advisory. Codex does not automatically run Claude Code hooks. |
+| Claude Flow, swarms, hive mind | Use only if matching MCP/tools are connected. Otherwise preserve the intent with normal Codex planning and execution. |
+| Use Opus | Use the active Codex model. Mention model-specific requirements only if they affect risk or scope. |
+
+## Precedence
+
+1. Current user instructions.
+2. `AGENTS.md`.
+3. Safety and filesystem rules from the active Codex environment.
+4. `CLAUDE.md`.
+5. The loaded `.claude/commands/*.md` prompt.
+6. This compatibility guide.
+
+## Missing Tools
+
+When a loaded command requires an MCP that is not available, follow the Missing
+Tool Alert Protocol from `AGENTS.md`, unless the user explicitly says to proceed
+without discussing MCPs.
+

--- a/.codex/context/dannflow.md
+++ b/.codex/context/dannflow.md
@@ -1,0 +1,45 @@
+# DannFlow Notes for Codex
+
+DannFlow is a Next.js 15+, React 19, Supabase, Tailwind v4, Shadcn/UI starter
+optimized for AI-assisted development.
+
+## Operating Order
+
+1. Read `AGENTS.md` before taking action.
+2. Read `CLAUDE.md` for richer project context.
+3. For feature work, check `PROJECT_CONTEXT.md` if present.
+4. For new features, check `src/prompts/features/` before scaffolding.
+5. Keep business logic and Supabase queries in `src/services/`.
+6. Use generated types from `src/types/supabase.ts`; never use `any`.
+
+## Database Discipline
+
+Assume RLS is active on every table. Service queries must include explicit user,
+tenant, or ownership filters unless the endpoint is intentionally public.
+
+Before schema-sensitive work:
+
+```bash
+npm run checkpoint
+npm run update-types
+```
+
+Use Supabase MCP for live schema reads and migrations when available.
+
+## UI Discipline
+
+Use Tailwind and Shadcn semantic tokens only:
+
+- Backgrounds: `bg-background`, `bg-card`, `bg-muted`
+- Text: `text-foreground`, `text-muted-foreground`, `text-primary`
+- Borders: `border`, `border-border`, `border-input`
+- Brand: `bg-primary`, `text-primary-foreground`
+
+Avoid raw `button` elements for app UI. Use Shadcn `Button`.
+
+## Codex Command Bridge
+
+The `.claude/commands/` files remain the command source of truth. Codex should
+load those prompts through `.codex/commands/claude-command.md` instead of copying
+or rewriting them.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ To fix:
 -   If you encounter a bug, fix it in the **Service** layer first.
 -   If you need a new data structure, define or request generation of its types in `src/types/` first.
 -   **GitHub MCP Mastery**: Use the GitHub MCP whenever the user reports a regression or a merge conflict. Compare current files with historical commits before asking for manual diffs.
+-   **Codex Compatibility**: If the user invokes `/claude-command <command> [args]`, read `.codex/commands/claude-command.md`, resolve the matching `.claude/commands/*.md` file, replace `$ARGUMENTS` with the provided args, and execute the loaded prompt under these AGENTS.md rules.
+-   **Command Source of Truth**: Keep `.claude/commands/` as the canonical command library. Do not duplicate every Claude command into `.codex/`; `.codex/` is the adapter/context layer for Codex.
 -   **Backup & Snapshot**: If the user runs `npm run checkpoint` and provides the generated prompt, you must:
     1. Verify Supabase MCP connection.
     2. Read the live schema (Tables, Enums, RLS, Triggers) for the specified project ID.
@@ -92,4 +94,18 @@ Always check `src/types/supabase.ts` and **assume RLS is active on every table**
 
 ## Project Overview
 A high-performance Next.js starter optimized for AI-native development (Vibe Coding), featuring automated type-safety and live database orchestration.
+
+## Codex Command Bridge
+DannFlow supports Codex through the `.codex/` folder:
+
+- `.codex/commands/claude-command.md` defines `/claude-command <claude-command> [arguments]`.
+- `.codex/commands/ask-claude-command.md` routes a plain-English task to the best existing Claude command.
+- `.codex/context/claude-compatibility.md` translates Claude-only concepts such as Ruflo memory, Claude hooks, Claude Flow, swarms, and model names into Codex behavior.
+
+When running a Claude command from Codex:
+1. Read `AGENTS.md` first, then `CLAUDE.md`.
+2. Resolve the command from `.claude/commands/`.
+3. Replace `$ARGUMENTS` with the user-provided argument string.
+4. Follow the loaded command unless it conflicts with AGENTS.md, active user instructions, or Codex environment safety rules.
+5. If the command requires unavailable MCP tooling, use the Missing Tool Alert Protocol unless the user explicitly says to proceed without discussing MCPs.
 <!-- END:nextjs-agent-rules -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ If a required MCP is missing, stop and tell the user:
 | [SKILLS.md](SKILLS.md) | Which Claude Code skills are relevant + when to invoke them |
 | `.claude/commands/` | Custom slash commands (see its README for the list) |
 | `AGENTS.md` | Cross-tool agent standard (Cursor/Antigravity/etc.) — kept for compatibility |
+| `.codex/` | Codex compatibility layer that loads `.claude/commands/` through `/claude-command` |
 
 If you don't know which custom command fits a task, run `/ask-command <your intent>`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🚀 DannFlow (2026 Edition)
 
-**The Claude Code-Optimized SaaS Starter.** Built for AI-assisted development with Claude Code, Cursor, or Antigravity — Next.js 15+, Supabase, Tailwind v4, Shadcn UI, with auth, dashboard, RLS-first design, and 34 built-in slash commands.
+**The AI-agent-optimized SaaS Starter.** Built for AI-assisted development with Claude Code, Codex, Cursor, or Antigravity — Next.js 15+, Supabase, Tailwind v4, Shadcn UI, with auth, dashboard, RLS-first design, and a reusable command system.
 
 > **Built for Speed. Structured for Agents. Optimized for the Vibe.**
 
@@ -51,6 +51,37 @@ npm run dev
 ```
 
 **Want Claude to design the whole site for you?** After the 5 steps, run **`/design-project`** (⭐ on Opus) — it reads your `README` + `business.json` + `PROJECT_CONTEXT`, runs a quick design-taste interview, then designs and builds every section with real copy and a fitting theme, replacing all template placeholders. Spinning up a fresh client/business project from scratch instead? **`/new-project`** does the full Phase-1 scaffold (config + GitHub repo + `origin` repoint + Supabase tenant) before you hand off to `/design-project`.
+
+---
+
+## Codex Workflow
+
+DannFlow keeps the existing `.claude/commands/` library as the command source of
+truth and adds a thin `.codex/` compatibility layer for Codex.
+
+Use Codex commands like this:
+
+```text
+/claude-command <claude-command> [arguments]
+```
+
+Examples:
+
+```text
+/claude-command ui src/components/BillingForm.tsx
+/claude-command new-feature billing
+/claude-command sync-upstream --commits 3
+```
+
+If you do not know which command fits, ask Codex to route it:
+
+```text
+/ask-claude-command make the pricing page responsive and review it
+```
+
+Codex will read `AGENTS.md`, load the exact matching `.claude/commands/*.md`
+prompt, replace `$ARGUMENTS`, and translate Claude-only concepts such as Ruflo
+memory, Claude hooks, and swarms using `.codex/context/claude-compatibility.md`.
 
 ---
 
@@ -246,13 +277,20 @@ supabase/
 ├── agents/           # Ruflo agent definitions
 ├── skills/           # Installed skill packs
 └── settings.json     # Ruflo hook wiring
+
+.codex/
+├── commands/         # Codex commands that load .claude command prompts
+├── context/          # DannFlow + Claude compatibility notes for Codex
+└── adapters/         # Command-loading contract
 ```
 
 ---
 
 ## ⚡ Slash Commands
 
-Run `./guide.sh commands` to see all 34 commands. Key ones:
+Run `./guide.sh commands` or read `.claude/commands/README.md` to see the core
+DannFlow commands. The repository also includes additional command packs under
+`.claude/commands/`. Key ones:
 
 | Command | When to use |
 |---|---|
@@ -267,6 +305,18 @@ Run `./guide.sh commands` to see all 34 commands. Key ones:
 | `/review` | Pre-commit lint + typecheck + guardrail check |
 | `/commit` | Stage + draft conventional commit message |
 | `/rls-check` | Audit RLS policies for missing tenant filters |
+
+### Running Claude commands from Codex
+
+Use the Codex bridge instead of duplicating command files:
+
+```text
+/claude-command <command> [arguments]
+```
+
+For example, `/claude-command sync-upstream` loads
+`.claude/commands/sync-upstream.md` and runs it under Codex with DannFlow's
+agent guardrails.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a .codex compatibility layer for running existing .claude commands through Codex
- document /claude-command and /ask-claude-command usage
- update AGENTS.md, CLAUDE.md, and README.md with the Codex command bridge context

## Testing
- verified .codex command files exist
- verified .claude/commands/sync-upstream.md resolves as a source command
- checked final git status and staged diff before commit