### PR TITLE
feat: add tracked Supabase schema command

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -32,6 +32,7 @@ Drop `.md` files in this folder to add custom slash commands. Each file becomes 
 | `/no-conflict` | Audits repo for conflicts between documentation (README, CLAUDE.md) and actual code — technology versions, features, commands, RLS enforcement, semantic tokens, folder structure. Reports only. |
 | `/seed <table\|all>` | Generates realistic, type-safe seed data from `src/types/supabase.ts`. Respects FK order and RLS ownership. Writes to `supabase/seeds/`. |
 | `/migrate <description>` | Edits `db/schema/*.ts`, generates SQL in `db/migrations/`, applies with `pnpm db:migrate`, verifies Supabase, and syncs types. |
+| `/schema-change <description>` | Explicit live Supabase MCP schema workflow: checkpoint → approved SQL → tracked `db/migrations/*.sql` file → apply_migration → sync types → verify. |
 | `/seo-check [route]` | Per-route SEO audit: metadata, OG, canonical, sitemap.ts, robots.ts, JSON-LD, alt text, heading hierarchy. Reports only. |
 | `/seo-fix <route\|all>` | Active rewrite — adds missing SEO essentials. Scaffolds `sitemap.ts`, `robots.ts`, metadata blocks, JSON-LD. Plan-then-confirm. |
 | `/marketing-check [route]` | Conversion-fundamentals audit for landing/marketing pages — headline, CTA, social proof, friction, pricing legibility. Opinionated, judgement-heavy. Reports only. |

--- a/.claude/commands/schema-change.md
+++ b/.claude/commands/schema-change.md
@@ -1,0 +1,166 @@
+---
+description: Applies an explicit Supabase MCP schema change, records the approved SQL in a tracked migration file, regenerates TypeScript types, and verifies RLS.
+argument-hint: <plain-english schema change>
+---
+
+Execute a complete tracked Supabase schema change described by `$ARGUMENTS`.
+
+Use this command when the user explicitly wants to manipulate the live Supabase schema through MCP or needs to backport an emergency live SQL change into the repo. For normal planned app schema work, prefer `/migrate`, which edits `db/schema/*.ts`, generates `db/migrations/*.sql`, runs `pnpm db:migrate`, and keeps Drizzle as the source of truth.
+
+This command chains:
+
+`/checkpoint` -> draft SQL -> create tracked migration SQL -> Supabase MCP `apply_migration` -> `/sync-types` -> verification.
+
+## Procedure
+
+### Step 0 - Confirm tooling
+
+Verify these are available before doing schema work:
+
+- Supabase MCP, for live schema reads, `apply_migration`, RLS/policy checks, advisors, and verification.
+- Terminal, for reading/writing the tracked SQL migration file and running `/sync-types`.
+
+If Supabase MCP is unavailable, stop and use the AGENTS.md Missing Tool Alert Protocol.
+
+### Step 1 - Understand the request
+
+Parse `$ARGUMENTS` into a concrete schema change. If it is ambiguous, ask one clarifying question.
+
+Check the live schema first with Supabase MCP. Do not assume table or column shape from memory.
+
+### Step 2 - Checkpoint first
+
+Run the `/checkpoint` flow and save a full live-schema backup under:
+
+`supabase/backups/schema-MM-DD-YYYY-HH-MM.sql`
+
+Do not continue if the checkpoint fails.
+
+### Step 3 - Draft SQL
+
+Draft the SQL required for the change.
+
+Include, where applicable:
+
+- Tables, columns, constraints, defaults, and comments.
+- Indexes for foreign keys and commonly filtered columns.
+- `updated_at` triggers for mutable tables.
+- RLS enablement and policies for every new exposed table.
+- Ownership predicates consistent with the existing app model.
+
+Security rules:
+
+- Every new exposed table must enable RLS.
+- Policies must use `TO authenticated` plus ownership predicates; do not rely on role checks alone.
+- UPDATE policies need both `USING` and `WITH CHECK`.
+- Avoid `SECURITY DEFINER` unless there is a clear reason and the function is locked down.
+
+Show the full SQL to the user before applying it.
+
+For destructive changes (`DROP`, `TRUNCATE`, type narrowing, removing constraints, or adding `NOT NULL` to existing nullable data), require the user to type `yes`.
+
+### Step 4 - Create a tracked migration file
+
+Before applying the SQL, save the exact approved SQL to a tracked migration file.
+
+Preferred location for this repo:
+
+`db/migrations/YYYYMMDDHHMMSS_<snake_case_name>.sql`
+
+Use the current local timestamp and a concise snake_case name derived from the request, for example:
+
+`db/migrations/20260628143000_add_bio_to_profiles.sql`
+
+The file must include a short header comment:
+
+```sql
+-- DannFlow tracked Supabase MCP migration
+-- Applied via Supabase MCP apply_migration: <migration_name>
+-- Checkpoint: supabase/backups/<checkpoint_file>.sql
+```
+
+Then include the exact SQL that will be sent to Supabase MCP.
+
+If the project has adopted native Supabase migration files, create the file with `supabase migration new <name>` first instead of inventing a filename.
+
+### Step 5 - Apply via Supabase MCP
+
+Call Supabase MCP `apply_migration` with:
+
+- `name`: the same snake_case migration name used in the file.
+- `query`: the exact SQL saved in the migration file, excluding only header comments if needed.
+
+If apply fails:
+
+- Report the exact error.
+- Keep the migration file for review unless the user asks to remove it.
+- Cite the rollback checkpoint.
+- Do not run `/sync-types`.
+
+### Step 6 - Sync TypeScript types
+
+Run `/sync-types`, which regenerates:
+
+`src/types/supabase.ts`
+
+Never edit `src/types/supabase.ts` manually.
+
+Summarize the generated type drift:
+
+- New tables.
+- Removed tables.
+- Added, removed, or changed columns.
+- Enum changes.
+
+### Step 7 - Backport schema source when needed
+
+If this live change affects app-owned tables represented in `db/schema/*.ts`, update the matching Drizzle schema files after the MCP migration succeeds.
+
+Then run:
+
+```bash
+pnpm db:generate
+```
+
+If Drizzle generates an overlapping migration, reconcile it with the tracked SQL file so the repo has one authoritative migration for the change.
+
+### Step 8 - Verify live database state
+
+Use Supabase MCP to verify the change:
+
+- For new tables: confirm the table exists and list columns.
+- For altered tables: confirm the new/changed column or constraint exists.
+- For dropped objects: confirm the object is gone.
+- For RLS changes: list policies and confirm RLS is enabled.
+
+### Step 9 - Report
+
+Report in this format:
+
+```text
+Schema change applied: <migration_name>
+
+Files:
+  - Migration: db/migrations/<timestamp>_<name>.sql
+  - Types: src/types/supabase.ts
+  - Checkpoint: supabase/backups/<checkpoint>.sql
+  - Schema source: db/schema/<file>.ts or n/a
+
+Verified:
+  - <specific live database verification>
+  - RLS: <enabled/policies confirmed/n/a>
+
+Suggested commit:
+  feat(db): <short schema change>
+```
+
+## Constraints
+
+- Always checkpoint first.
+- Always save the approved SQL to a tracked migration file before applying it.
+- Always apply the exact approved SQL with Supabase MCP `apply_migration`.
+- Always regenerate `src/types/supabase.ts` after a successful schema change.
+- Backport app-owned table changes into `db/schema/*.ts`.
+- Never manually edit generated types.
+- Never report success until live verification is complete.
+- Never `git add` or `git commit` from this command.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ To fix:
     2. Read the live schema (Tables, Enums, RLS, Triggers) for the specified project ID.
     3. Generate the full DDL and save it to the specified timestamped SQL file in `supabase/backups/`.
 -   **Schema Source of Truth**: Database schema is authored in `db/schema/*.ts` with Drizzle. For normal schema changes, edit `db/schema/`, run `pnpm db:generate`, review `db/migrations/*.sql`, then run `pnpm db:migrate`. Do **not** use Supabase MCP `apply_migration` or direct SQL for normal schema changes unless the user explicitly requests an emergency live hotfix.
--   **Emergency Schema Hotfixes**: If a schema change is made directly through Supabase MCP or SQL, immediately backport the change into `db/schema/*.ts`, generate a matching migration with `pnpm db:generate`, and refresh `src/types/supabase.ts`. Never leave live schema drift untracked.
+-   **Explicit Supabase MCP Schema Changes**: If the user explicitly asks to manipulate the live Supabase schema through MCP, use `.claude/commands/schema-change.md`. The tracked flow must checkpoint first, save the approved SQL to `db/migrations/YYYYMMDDHHMMSS_<name>.sql`, apply the exact SQL with Supabase MCP `apply_migration`, regenerate `src/types/supabase.ts`, verify the live schema/RLS state, and backport app-owned table changes into `db/schema/*.ts`.
+-   **Emergency Schema Hotfixes**: If a schema change is made directly through Supabase MCP or SQL, immediately backport the change into `db/schema/*.ts`, generate or reconcile a matching migration in `db/migrations/`, and refresh `src/types/supabase.ts`. Never leave live schema drift untracked.
 -   **Project Provisioning**: If requested to create a new project and apply a schema:
     1. List organizations to help the user choose one.
     2. Ask for the Project Name and Organization ID.
@@ -92,8 +93,9 @@ Always check `src/types/supabase.ts` and **assume RLS is active on every table**
 1. **Schema Source of Truth**: Author tables, columns, indexes, and relations in `db/schema/*.ts` with Drizzle.
 2. **Migration Flow**: Run `pnpm db:generate` to create SQL in `db/migrations/`, review the SQL, then run `pnpm db:migrate` to apply it to Supabase and refresh generated types.
 3. **MCP Read/Verify Role**: Use the Supabase MCP for live schema reads, verification, advisors, project provisioning, and checkpoint snapshots. Do not use MCP `apply_migration` for normal tracked schema changes.
-4. **Sync Types**: After any schema change, refresh `src/types/supabase.ts` using `pnpm db:migrate`, `pnpm db:types`, or `pnpm db:types:remote`. Rely ONLY on these generated definitions in app code.
-5. **RLS Constraint**: Always assume Row Level Security (RLS) is active. New tables require explicit RLS policies in the generated SQL migration before it is applied.
+4. **Explicit MCP Mutation Flow**: When the user explicitly requests live Supabase schema manipulation through MCP, use `.claude/commands/schema-change.md` so the approved SQL is tracked in `db/migrations/`, types are regenerated, and app-owned schema changes are backported into `db/schema/*.ts`.
+5. **Sync Types**: After any schema change, refresh `src/types/supabase.ts` using `pnpm db:migrate`, `pnpm db:types`, or `pnpm db:types:remote`. Rely ONLY on these generated definitions in app code.
+6. **RLS Constraint**: Always assume Row Level Security (RLS) is active. New tables require explicit RLS policies in the generated SQL migration before it is applied.
 
 ## Project Overview
 A high-performance Next.js starter optimized for AI-native development (Vibe Coding), featuring automated type-safety and live database orchestration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,8 @@ Theme variables live in `src/app/globals.css` under `@theme`.
 
 Do **not** use Supabase MCP `apply_migration` for normal schema changes. Supabase MCP is for reading, verifying, advisors, provisioning, and checkpointing. If an emergency live SQL change is explicitly requested, backport it immediately into `db/schema/*.ts` and `db/migrations/`.
 
+Use `.claude/commands/schema-change.md` only when the user explicitly wants to manipulate the live Supabase schema through MCP or needs an emergency live SQL change captured in git. That command checkpoints the live schema, writes the approved SQL to `db/migrations/YYYYMMDDHHMMSS_<name>.sql`, applies it through Supabase MCP `apply_migration`, regenerates `src/types/supabase.ts`, verifies the live database, and backports app-owned table changes into `db/schema/*.ts`.
+
 ### Checkpoint protocol
 When the user runs `pnpm checkpoint` and provides the generated prompt:
 1. Verify Supabase MCP connection.


### PR DESCRIPTION
## Summary
- add /schema-change for explicit Supabase MCP schema mutations with tracked SQL migration files
- document when to use /schema-change versus the normal Drizzle-first /migrate workflow
- update CLAUDE.md and AGENTS.md so live MCP schema changes regenerate types, verify RLS, and backport app-owned schema

## Verification
- reviewed staged diff in clean DannFlow clone
- scanned contribution files for AttyJuan-specific strings and common secret markers